### PR TITLE
New feature: Kalman filter with missing (NaN) values

### DIFF
--- a/src/MacroModelling.jl
+++ b/src/MacroModelling.jl
@@ -8635,7 +8635,8 @@ function run_kalman_iterations(A::Matrix{S}, 𝐁::Matrix{S}, C::Matrix{Float64}
     Ptmp = similar(P)
 
     for t in 1:size(data_in_deviations, 2)
-        ℒ.axpby!(1, data_in_deviations[:, t], -1, z)
+         z = replace(ℒ.axpby!(1, data_in_deviations[:, t], -1, z),NaN=>0)
+	# ℒ.axpby!(1, data_in_deviations[:, t], -1, z)
         # v = data_in_deviations[:, t] - z
 
         mul!(Ctmp, C, P) # use Octavian.jl


### PR DESCRIPTION
Hi Thore, I saw it on your to-do list. 

I always wished to be contributor to your wonderful project, thus I decided to make it happen, not the least it comes handy in my own work.

The change is super simple and works. In the Kalman iteration just replace:

ℒ.axpby!(1, data_in_deviations[:, t], -1, z)  

with:

z = replace(ℒ.axpby!(1, data_in_deviations[:, t], -1, z),NaN=>0)   # v = data_in_deviations[:, t] - z

Using julia's missing gave me type errors and headache with Turing. Changing to NaN -s opened a shortcut to just call a replace whenever a missing value it is encountered in the KF iteration, due to missing data, then the prediction error is set to zero, leading to no update. Let me know what you think!