### PR TITLE
Add caching for QME doubling

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -43,13 +43,13 @@ function run_benchmarks!(𝓂::ℳ, SUITE::BenchmarkGroup)
     
     SUITE[𝓂.model_name]["qme"] = BenchmarkGroup()
     
-    sol, qme_sol, solved = calculate_first_order_solution(∇₁; T = 𝓂.timings, opts = merge_calculation_options(quadratic_matrix_equation_algorithm = :schur))
+    sol, qme_sol, solved = calculate_first_order_solution(∇₁; T = 𝓂.timings, opts = merge_calculation_options(quadratic_matrix_equation_algorithm = :schur), 𝒬ℂ = 𝓂.caches.qme_caches)
     
     clear_solution_caches!(𝓂, :first_order)
     
-    SUITE[𝓂.model_name]["qme"]["schur"] = @benchmarkable calculate_first_order_solution($∇₁; T = $𝓂.timings, opts = merge_calculation_options(quadratic_matrix_equation_algorithm = :schur)) setup = clear_solution_caches!($𝓂, :first_order)
+    SUITE[𝓂.model_name]["qme"]["schur"] = @benchmarkable calculate_first_order_solution($∇₁; T = $𝓂.timings, opts = merge_calculation_options(quadratic_matrix_equation_algorithm = :schur), 𝒬ℂ = $𝓂.caches.qme_caches) setup = clear_solution_caches!($𝓂, :first_order)
     
-    SUITE[𝓂.model_name]["qme"]["doubling"] = @benchmarkable calculate_first_order_solution($∇₁; T = $𝓂.timings, opts = merge_calculation_options(quadratic_matrix_equation_algorithm = :doubling)) setup = clear_solution_caches!($𝓂, :first_order)
+    SUITE[𝓂.model_name]["qme"]["doubling"] = @benchmarkable calculate_first_order_solution($∇₁; T = $𝓂.timings, opts = merge_calculation_options(quadratic_matrix_equation_algorithm = :doubling), 𝒬ℂ = $𝓂.caches.qme_caches) setup = clear_solution_caches!($𝓂, :first_order)
     
     
     A = @views sol[:, 1:𝓂.timings.nPast_not_future_and_mixed] * ℒ.diagm(ones(𝓂.timings.nVars))[𝓂.timings.past_not_future_and_mixed_idx,:]

--- a/src/MacroModelling.jl
+++ b/src/MacroModelling.jl
@@ -692,6 +692,7 @@ function clear_solution_caches!(𝓂::ℳ, algorithm::Symbol)
     𝓂.solution.perturbation.qme_solution = zeros(0,0)
     𝓂.solution.perturbation.second_order_solution = spzeros(0,0)
     𝓂.solution.perturbation.third_order_solution = spzeros(0,0)
+    𝓂.caches.qme_caches = QME_caches()
 
     return nothing
 end
@@ -5042,10 +5043,11 @@ function calculate_second_order_stochastic_steady_state(parameters::Vector{M},
 
     # @timeit_debug timer "Calculate first order solution" begin
 
-    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                        T = 𝓂.timings, 
+    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                        T = 𝓂.timings,
                                                         opts = opts,
-                                                        initial_guess = 𝓂.solution.perturbation.qme_solution)
+                                                        initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                        𝒬ℂ = 𝓂.caches.qme_caches)
 
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -5369,10 +5371,11 @@ function calculate_third_order_stochastic_steady_state( parameters::Vector{M},
 
     ∇₁ = calculate_jacobian(parameters, SS_and_pars, 𝓂)# |> Matrix
     
-    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                        T = 𝓂.timings, 
+    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                        T = 𝓂.timings,
                                                         opts = opts,
-                                                        initial_guess = 𝓂.solution.perturbation.qme_solution)
+                                                        initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                        𝒬ℂ = 𝓂.caches.qme_caches)
     
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -5754,10 +5757,11 @@ function solve!(𝓂::ℳ;
 
             # @timeit_debug timer "Calculate first order solution" begin
 
-            S₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                                T = 𝓂.timings, 
+            S₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                                T = 𝓂.timings,
                                                                 opts = opts,
-                                                                initial_guess = 𝓂.solution.perturbation.qme_solution)
+                                                                initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                                𝒬ℂ = 𝓂.caches.qme_caches)
     
             if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -5776,10 +5780,11 @@ function solve!(𝓂::ℳ;
 
                 ∇̂₁ = calculate_jacobian(𝓂.parameter_values, SS_and_pars, 𝓂)# |> Matrix
             
-                Ŝ₁, qme_sol, solved = calculate_first_order_solution(∇̂₁; 
-                                                                    T = 𝓂.timings, 
-                                                                    opts = opts,
-                                                                    initial_guess = 𝓂.solution.perturbation.qme_solution)
+               Ŝ₁, qme_sol, solved = calculate_first_order_solution(∇̂₁;
+                                                                   T = 𝓂.timings,
+                                                                   opts = opts,
+                                                                    initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                                    𝒬ℂ = 𝓂.caches.qme_caches)
 
                 if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -8358,11 +8363,12 @@ function get_relevant_steady_state_and_state_update(::Val{:first_order},
 
     ∇₁ = calculate_jacobian(parameter_values, SS_and_pars, 𝓂) # , timer = timer)# |> Matrix
 
-    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                        T = TT, 
-                                                        # timer = timer, 
-                                                        initial_guess = 𝓂.solution.perturbation.qme_solution, 
-                                                        opts = opts)
+    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                        T = TT,
+                                                        # timer = timer,
+                                                        initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                        opts = opts,
+                                                        𝒬ℂ = 𝓂.caches.qme_caches)
 
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 

--- a/src/algorithms/quadratic_matrix_equation.jl
+++ b/src/algorithms/quadratic_matrix_equation.jl
@@ -296,12 +296,14 @@ function solve_quadratic_matrix_equation(A::AbstractMatrix{R},
         # @timeit_debug timer "Invert EI" begin
 
         alg = issparse(temp1) ? 𝒮.UMFPACKFactorization() : 𝒮.LUFactorization()
-        if !(typeof(𝒬ℂ.EI_cache.alg) === typeof(alg))
-            prob = 𝒮.LinearProblem(copy(temp1), E, alg)
+        if !(typeof(𝒬ℂ.EI_cache.alg) === typeof(alg)) ||
+            size(𝒬ℂ.EI_cache.A) != size(temp1) ||
+            size(𝒬ℂ.EI_cache.b) != size(E)
+            prob = 𝒮.LinearProblem(copy(temp1), copy(E), alg)
             𝒬ℂ.EI_cache = 𝒮.init(prob, alg)
         else
-            𝒬ℂ.EI_cache.A = temp1
-            𝒬ℂ.EI_cache.b = E
+            𝒬ℂ.EI_cache.A .= temp1
+            𝒬ℂ.EI_cache.b .= E
             𝒬ℂ.EI_cache.isfresh = true
         end
         𝒮.solve!(𝒬ℂ.EI_cache)
@@ -326,12 +328,14 @@ function solve_quadratic_matrix_equation(A::AbstractMatrix{R},
         # @timeit_debug timer "Invert FI" begin
 
         fFI_cache_alg = issparse(temp2) ? 𝒮.UMFPACKFactorization() : 𝒮.LUFactorization()
-        if !(typeof(𝒬ℂ.FI_cache.alg) === typeof(fFI_cache_alg))
-            prob = 𝒮.LinearProblem(copy(temp2), F, fFI_cache_alg)
+        if !(typeof(𝒬ℂ.FI_cache.alg) === typeof(fFI_cache_alg)) ||
+            size(𝒬ℂ.FI_cache.A) != size(temp2) ||
+            size(𝒬ℂ.FI_cache.b) != size(F)
+            prob = 𝒮.LinearProblem(copy(temp2), copy(F), fFI_cache_alg)
             𝒬ℂ.FI_cache = 𝒮.init(prob, fFI_cache_alg)
         else
-            𝒬ℂ.FI_cache.A = temp2
-            𝒬ℂ.FI_cache.b = F
+            𝒬ℂ.FI_cache.A .= temp2
+            𝒬ℂ.FI_cache.b .= F
             𝒬ℂ.FI_cache.isfresh = true
         end
         𝒮.solve!(𝒬ℂ.FI_cache)

--- a/src/filter/inversion.jl
+++ b/src/filter/inversion.jl
@@ -3457,10 +3457,11 @@ function filter_data_with_model(𝓂::ℳ,
 
     ∇₁ = calculate_jacobian(𝓂.parameter_values, SS_and_pars, 𝓂)# |> Matrix
 
-    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                        T = T, 
-                                                        initial_guess = 𝓂.solution.perturbation.qme_solution, 
-                                                        opts = opts)
+    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                        T = T,
+                                                        initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                        opts = opts,
+                                                        𝒬ℂ = 𝓂.caches.qme_caches)
     
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 

--- a/src/filter/kalman.jl
+++ b/src/filter/kalman.jl
@@ -601,7 +601,7 @@ function filter_and_smooth(𝓂::ℳ,
 
 	∇₁ = calculate_jacobian(parameters, SS_and_pars, 𝓂)# |> Matrix
 
-    sol, qme_sol, solved = calculate_first_order_solution(∇₁; T = 𝓂.timings, opts = opts)
+    sol, qme_sol, solved = calculate_first_order_solution(∇₁; T = 𝓂.timings, opts = opts, 𝒬ℂ = 𝓂.caches.qme_caches)
 
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 

--- a/src/get_functions.jl
+++ b/src/get_functions.jl
@@ -1025,10 +1025,11 @@ function get_irf(𝓂::ℳ,
 
 	∇₁ = calculate_jacobian(parameters, reference_steady_state, 𝓂)# |> Matrix
 								
-    sol_mat, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                            T = 𝓂.timings, 
+    sol_mat, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                            T = 𝓂.timings,
                                                             opts = opts,
-                                                            initial_guess = 𝓂.solution.perturbation.qme_solution)
+                                                            initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                            𝒬ℂ = 𝓂.caches.qme_caches)
     
     if solved 
         𝓂.solution.perturbation.qme_solution = qme_sol
@@ -1987,9 +1988,10 @@ function get_solution(𝓂::ℳ,
 
 	∇₁ = calculate_jacobian(parameters, SS_and_pars, 𝓂)# |> Matrix
 
-    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; T = 𝓂.timings, 
+    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; T = 𝓂.timings,
                                                         opts = opts,
-                                                        initial_guess = 𝓂.solution.perturbation.qme_solution)
+                                                        initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                        𝒬ℂ = 𝓂.caches.qme_caches)
     
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -2172,10 +2174,11 @@ function get_conditional_variance_decomposition(𝓂::ℳ;
     
 	∇₁ = calculate_jacobian(𝓂.parameter_values, SS_and_pars, 𝓂)# |> Matrix
 
-    𝑺₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                        T = 𝓂.timings, 
+    𝑺₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                        T = 𝓂.timings,
                                                         opts = opts,
-                                                        initial_guess = 𝓂.solution.perturbation.qme_solution)
+                                                        initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                        𝒬ℂ = 𝓂.caches.qme_caches)
     
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -2331,10 +2334,11 @@ function get_variance_decomposition(𝓂::ℳ;
     
 	∇₁ = calculate_jacobian(𝓂.parameter_values, SS_and_pars, 𝓂)# |> Matrix
 
-    sol, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                            T = 𝓂.timings, 
-            opts = opts, 
-                                                            initial_guess = 𝓂.solution.perturbation.qme_solution)
+    sol, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                            T = 𝓂.timings,
+            opts = opts,
+                                                            initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                            𝒬ℂ = 𝓂.caches.qme_caches)
     
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -11,10 +11,11 @@ function calculate_covariance(parameters::Vector{R},
 
 	∇₁ = calculate_jacobian(parameters, SS_and_pars, 𝓂) 
 
-    sol, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                            T = 𝓂.timings, 
-                                                            initial_guess = 𝓂.solution.perturbation.qme_solution, 
-                                                            opts = opts)
+    sol, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                            T = 𝓂.timings,
+                                                            initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                            opts = opts,
+                                                            𝒬ℂ = 𝓂.caches.qme_caches)
 
     if solved 𝓂.solution.perturbation.qme_solution = qme_sol end
 
@@ -56,10 +57,11 @@ function calculate_mean(parameters::Vector{T},
     else
         ∇₁ = calculate_jacobian(parameters, SS_and_pars, 𝓂)# |> Matrix
         
-        𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁; 
-                                                            T = 𝓂.timings, 
-                                                            initial_guess = 𝓂.solution.perturbation.qme_solution, 
-                                                            opts = opts)
+        𝐒₁, qme_sol, solved = calculate_first_order_solution(∇₁;
+                                                            T = 𝓂.timings,
+                                                            initial_guess = 𝓂.solution.perturbation.qme_solution,
+                                                            opts = opts,
+                                                            𝒬ℂ = 𝓂.caches.qme_caches)
         
         if !solved 
             mean_of_variables = SS_and_pars[1:𝓂.timings.nVars]

--- a/src/options_and_caches.jl
+++ b/src/options_and_caches.jl
@@ -12,6 +12,21 @@ mutable struct sylvester_caches{G <: AbstractFloat}
     krylov_caches::krylov_caches{G}
 end
 
+mutable struct qme_caches
+    EI_cache::𝒮.LinearCache
+    FI_cache::𝒮.LinearCache
+end
+
+function QME_caches(;T::Type = Float64)
+    A = Matrix{T}(I, 1, 1)
+    b = zeros(T, 1)
+    alg = 𝒮.LUFactorization()
+    prob = 𝒮.LinearProblem(A, b, alg)
+    EI = 𝒮.init(prob, alg)
+    FI = 𝒮.init(prob, alg)
+    return qme_caches(EI, FI)
+end
+
 mutable struct higher_order_caches{F <: Real, G <: AbstractFloat}
     tmpkron0::SparseMatrixCSC{F, Int}
     tmpkron1::SparseMatrixCSC{F, Int}
@@ -32,6 +47,7 @@ end
 mutable struct caches#{F <: Real, G <: AbstractFloat}
     second_order_caches::higher_order_caches#{F, G}
     third_order_caches::higher_order_caches#{F, G}
+    qme_caches::qme_caches
 end
 
 
@@ -67,7 +83,8 @@ end
 
 function Caches(;T::Type = Float64, S::Type = Float64)
     caches( Higher_order_caches(T = T, S = S),
-            Higher_order_caches(T = T, S = S))
+            Higher_order_caches(T = T, S = S),
+            QME_caches(T = S))
 end
 
 

--- a/src/options_and_caches.jl
+++ b/src/options_and_caches.jl
@@ -19,7 +19,7 @@ end
 
 function QME_caches(;T::Type = Float64)
     A = Matrix{T}(I, 1, 1)
-    b = zeros(T, 1)
+    b = zeros(T, 1, 1)
     alg = 𝒮.LUFactorization()
     prob = 𝒮.LinearProblem(A, b, alg)
     EI = 𝒮.init(prob, alg)

--- a/src/perturbation.jl
+++ b/src/perturbation.jl
@@ -1,9 +1,10 @@
 @stable default_mode = "disable" begin
 
-function calculate_first_order_solution(∇₁::Matrix{R}; 
-                                        T::timings, 
+function calculate_first_order_solution(∇₁::Matrix{R};
+                                        T::timings,
                                         opts::CalculationOptions = merge_calculation_options(),
-                                        initial_guess::AbstractMatrix{R} = zeros(0,0))::Tuple{Matrix{R}, Matrix{R}, Bool} where R <: AbstractFloat
+                                        initial_guess::AbstractMatrix{R} = zeros(0,0),
+                                        𝒬ℂ::qme_caches = QME_caches())::Tuple{Matrix{R}, Matrix{R}, Bool} where R <: AbstractFloat
     # @timeit_debug timer "Calculate 1st order solution" begin
     # @timeit_debug timer "Preprocessing" begin
 
@@ -43,12 +44,13 @@ function calculate_first_order_solution(∇₁::Matrix{R};
     # end # timeit_debug
     # @timeit_debug timer "Quadratic matrix equation solve" begin
 
-    sol, solved = solve_quadratic_matrix_equation(Ã₊, Ã₀, Ã₋, T, 
+    sol, solved = solve_quadratic_matrix_equation(Ã₊, Ã₀, Ã₋, T,
                                                     initial_guess = initial_guess,
                                                     quadratic_matrix_equation_algorithm = opts.quadratic_matrix_equation_algorithm,
                                                     tol = opts.tol.qme_tol,
                                                     acceptance_tol = opts.tol.qme_acceptance_tol,
-                                                    verbose = opts.verbose)
+                                                    verbose = opts.verbose,
+                                                    𝒬ℂ = 𝒬ℂ)
 
     if !solved
         if opts.verbose println("Quadratic matrix equation solution failed.") end
@@ -117,11 +119,12 @@ end
 
 end # dispatch_doctor 
 
-function rrule(::typeof(calculate_first_order_solution), 
+function rrule(::typeof(calculate_first_order_solution),
                 ∇₁::Matrix{R};
-                T::timings, 
+                T::timings,
                 opts::CalculationOptions = merge_calculation_options(),
-                initial_guess::AbstractMatrix{R} = zeros(0,0)) where R <: AbstractFloat
+                initial_guess::AbstractMatrix{R} = zeros(0,0),
+                𝒬ℂ::qme_caches = QME_caches()) where R <: AbstractFloat
     # Forward pass to compute the output and intermediate values needed for the backward pass
     # @timeit_debug timer "Calculate 1st order solution" begin
     # @timeit_debug timer "Preprocessing" begin
@@ -162,12 +165,13 @@ function rrule(::typeof(calculate_first_order_solution),
     # end # timeit_debug
     # @timeit_debug timer "Quadratic matrix equation solve" begin
 
-    sol, solved = solve_quadratic_matrix_equation(Ã₊, Ã₀, Ã₋, T, 
+    sol, solved = solve_quadratic_matrix_equation(Ã₊, Ã₀, Ã₋, T,
                                                     initial_guess = initial_guess,
                                                     quadratic_matrix_equation_algorithm = opts.quadratic_matrix_equation_algorithm,
                                                     tol = opts.tol.qme_tol,
                                                     acceptance_tol = opts.tol.qme_acceptance_tol,
-                                                    verbose = opts.verbose)
+                                                    verbose = opts.verbose,
+                                                    𝒬ℂ = 𝒬ℂ)
 
     if !solved
         return (zeros(T.nVars,T.nPast_not_future_and_mixed + T.nExo), sol, false), x -> NoTangent(), NoTangent(), NoTangent()
@@ -276,10 +280,11 @@ end
 
 @stable default_mode = "disable" begin
 
-function calculate_first_order_solution(∇₁::Matrix{ℱ.Dual{Z,S,N}}; 
-                                        T::timings, 
+function calculate_first_order_solution(∇₁::Matrix{ℱ.Dual{Z,S,N}};
+                                        T::timings,
                                         opts::CalculationOptions = merge_calculation_options(),
-                                        initial_guess::AbstractMatrix{<:AbstractFloat} = zeros(0,0))::Tuple{Matrix{ℱ.Dual{Z,S,N}}, Matrix{Float64}, Bool} where {Z,S,N}
+                                        initial_guess::AbstractMatrix{<:AbstractFloat} = zeros(0,0),
+                                        𝒬ℂ::qme_caches = QME_caches())::Tuple{Matrix{ℱ.Dual{Z,S,N}}, Matrix{Float64}, Bool} where {Z,S,N}
     ∇̂₁ = ℱ.value.(∇₁)
 
     expand = [ℒ.I(T.nVars)[T.future_not_past_and_mixed_idx,:], ℒ.I(T.nVars)[T.past_not_future_and_mixed_idx,:]] 
@@ -287,7 +292,7 @@ function calculate_first_order_solution(∇₁::Matrix{ℱ.Dual{Z,S,N}};
     A = ∇̂₁[:,1:T.nFuture_not_past_and_mixed] * expand[1]
     B = ∇̂₁[:,T.nFuture_not_past_and_mixed .+ range(1,T.nVars)]
 
-    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇̂₁; T = T, opts = opts, initial_guess = initial_guess)
+    𝐒₁, qme_sol, solved = calculate_first_order_solution(∇̂₁; T = T, opts = opts, initial_guess = initial_guess, 𝒬ℂ = 𝒬ℂ)
 
     if !solved 
         return ∇₁, qme_sol, false


### PR DESCRIPTION
## Summary
- add `QME_caches` with preallocated `LinearCache` objects for EI and FI systems
- store and reuse these caches in the doubling solver

## Testing
- `apt-get update -y`
- `apt-get install -y julia` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406fa57dc0832fa5f23b0b69075011