### PR TITLE
Add bang plot functions

### DIFF
--- a/src/MacroModelling.jl
+++ b/src/MacroModelling.jl
@@ -134,10 +134,10 @@ end
 
 
 export @model, @parameters, solve!
-export plot_irfs, plot_irf, plot_IRF, plot_simulations, plot_solution, plot_simulation, plot_girf #, plot
-export plot_conditional_variance_decomposition, plot_forecast_error_variance_decomposition, plot_fevd, plot_model_estimates, plot_shock_decomposition
+export plot_irfs, plot_irf, plot_IRF, plot_simulations, plot_solution, plot_simulation, plot_girf, plot_irf!, plot_solution!, plot_simulation!, plot_simulations!, plot_girf! #, plot
+export plot_conditional_variance_decomposition, plot_forecast_error_variance_decomposition, plot_fevd, plot_model_estimates, plot_shock_decomposition, plot_conditional_variance_decomposition!, plot_model_estimates!, plot_shock_decomposition!, plot_fevd!, plot_forecast_error_variance_decomposition!
 export get_irfs, get_irf, get_IRF, simulate, get_simulation, get_simulations, get_girf
-export get_conditional_forecast, plot_conditional_forecast
+export get_conditional_forecast, plot_conditional_forecast, plot_conditional_forecast!
 export get_solution, get_first_order_solution, get_perturbation_solution, get_second_order_solution, get_third_order_solution
 export get_steady_state, get_SS, get_ss, get_non_stochastic_steady_state, get_stochastic_steady_state, get_SSS, steady_state, SS, SSS, ss, sss
 export get_non_stochastic_steady_state_residuals, get_residuals, check_residuals


### PR DESCRIPTION
## Summary
- allow overlaying of IRF and other plots using new bang functions
- reexport the new bang functions from `MacroModelling`
- combine plot panels by sorted titles so overlay order is consistent

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684077b171e0832f950876e399b02eba