### PR TITLE
Add Mooncake extension rrules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,6 +48,10 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [weakdeps]
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+
+[extensions]
+MacroModellingMooncakeExt = "Mooncake"
 
 [compat]
 ADTypes = "1.14.0"

--- a/docs/src/tutorials/estimation.md
+++ b/docs/src/tutorials/estimation.md
@@ -99,10 +99,10 @@ data = data(observables,:)
 Next we define the parameter priors using the Turing package. The `@model` macro of the Turing package allows us to define the prior distributions over the parameters and combine it with the (Kalman filter) loglikelihood of the model and parameters given the data with the help of the `get_loglikelihood` function. We define the prior distributions in an array and pass it on to the `arraydist` function inside the `@model` macro from the Turing package. It is also possible to define the prior distributions inside the macro but especially for reverse mode auto differentiation the `arraydist` function is substantially faster. When defining the prior distributions we can rely n the distribution implemented in the Distributions package. Note that the `μσ` parameter allows us to hand over the moments (`μ` and `σ`) of the distribution as parameters in case of the non-normal distributions (Gamma, Beta, InverseGamma), and we can also define upper and lower bounds truncating the distribution as third and fourth arguments to the distribution functions. Last but not least, we define the loglikelihood and add it to the posterior loglikelihood with the help of the `@addlogprob!` macro.
 
 ```@repl tutorial_2
-import Zygote
+import Mooncake
 import DynamicPPL
 import Turing
-import Turing: NUTS, sample, logpdf, AutoZygote
+import Turing: NUTS, sample, logpdf, AutoMooncake
 
 prior_distributions = [
     Beta(0.356, 0.02, μσ = true),           # alp
@@ -136,7 +136,7 @@ FS2000_loglikelihood = FS2000_loglikelihood_function(data, FS2000);
 
 n_samples = 1000
 
-chain_NUTS  = sample(FS2000_loglikelihood, NUTS(adtype = AutoZygote()), n_samples, progress = false);
+chain_NUTS  = sample(FS2000_loglikelihood, NUTS(adtype = AutoMooncake()), n_samples, progress = false);
 ```
 
 ### Inspect posterior
@@ -209,8 +209,8 @@ p
 Other than the mean and median of the posterior distribution we can also calculate the mode as follows:
 
 ```@repl tutorial_2
-modeFS2000 = Turing.maximum_a_posteriori(FS2000_loglikelihood, 
-                                        adtype = AutoZygote(), 
+modeFS2000 = Turing.maximum_a_posteriori(FS2000_loglikelihood,
+                                        adtype = AutoMooncake(),
                                         initial_params = FS2000.parameter_values)
 ```
 

--- a/ext/MacroModellingMooncakeExt.jl
+++ b/ext/MacroModellingMooncakeExt.jl
@@ -1,0 +1,24 @@
+module MacroModellingMooncakeExt
+
+using MacroModelling
+import Mooncake
+import Mooncake: @from_rrule, DefaultCtx
+
+@from_rrule DefaultCtx Tuple{typeof(calculate_first_order_solution), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(calculate_second_order_solution), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(calculate_third_order_solution), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(solve_sylvester_equation), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(solve_lyapunov_equation), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(find_shocks), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(calculate_inversion_filter_loglikelihood), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(run_kalman_iterations), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(mul_reverse_AD!), Vararg{Any}} false
+@from_rrule DefaultCtx Tuple{typeof(sparse_preallocated!), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(calculate_second_order_stochastic_steady_state), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(calculate_third_order_stochastic_steady_state), Vararg{Any}} true
+@from_rrule DefaultCtx Tuple{typeof(calculate_jacobian), Vararg{Any}} false
+@from_rrule DefaultCtx Tuple{typeof(calculate_hessian), Vararg{Any}} false
+@from_rrule DefaultCtx Tuple{typeof(calculate_third_order_derivatives), Vararg{Any}} false
+@from_rrule DefaultCtx Tuple{typeof(get_NSSS_and_parameters), Vararg{Any}} true
+
+end

--- a/test/rethink_parser.jl
+++ b/test/rethink_parser.jl
@@ -2083,7 +2083,7 @@ backend = AutoMooncake(; config=nothing)
 @benchmark jacobian!(model_dynamics, jac, prep, backend, vcat(stst,stst,stst,zeros(𝓂.timings.nExo)), Constant(vcat(𝓂.parameter_values, calib_pars, stst)))
 
 
-backend = AutoZygote()
+backend = AutoMooncake()
 
 @time prep = prepare_jacobian(model_dynamics, backend, vcat(stst,stst,stst,zeros(𝓂.timings.nExo)), Constant(vcat(𝓂.parameter_values, calib_pars, stst))); # 3.3s
 @time jacobian!(model_dynamics, jac, prep, backend, vcat(stst,stst,stst,zeros(𝓂.timings.nExo)), Constant(vcat(𝓂.parameter_values, calib_pars, stst))) # 1.3s

--- a/test/test_1st_order_inversion_filter_estimation.jl
+++ b/test/test_1st_order_inversion_filter_estimation.jl
@@ -43,7 +43,7 @@ end
 
 n_samples = 1000
 
-samps = @time sample(FS2000_loglikelihood_function(data, FS2000, :inversion), NUTS(adtype = ADTypes.AutoZygote()), n_samples, progress = true, initial_params = FS2000.parameter_values)
+samps = @time sample(FS2000_loglikelihood_function(data, FS2000, :inversion), NUTS(adtype = ADTypes.AutoMooncake()), n_samples, progress = true, initial_params = FS2000.parameter_values)
 
 println("Mean variable values (Zygote): $(mean(samps).nt.mean)")
 
@@ -51,7 +51,7 @@ sample_nuts = mean(samps).nt.mean
 
 modeFS2000i = Turing.maximum_a_posteriori(FS2000_loglikelihood_function(data, FS2000, :inversion), 
                                         Optim.LBFGS(linesearch = LineSearches.BackTracking(order = 3)), 
-                                        adtype = ADTypes.AutoZygote(), 
+              adtype = ADTypes.AutoMooncake(),
                                         initial_params = FS2000.parameter_values)
 
 println("Mode variable values: $(modeFS2000i.values); Mode loglikelihood: $(modeFS2000i.lp)")

--- a/test/test_2nd_order_estimation.jl
+++ b/test/test_2nd_order_estimation.jl
@@ -47,7 +47,7 @@ Random.seed!(30)
 
 n_samples = 500
 
-samps = @time sample(FS2000_loglikelihood_function(data, FS2000, :second_order), NUTS(adtype = ADTypes.AutoZygote()), n_samples, progress = true, initial_params = FS2000.parameter_values)
+samps = @time sample(FS2000_loglikelihood_function(data, FS2000, :second_order), NUTS(adtype = ADTypes.AutoMooncake()), n_samples, progress = true, initial_params = FS2000.parameter_values)
 
 println("Mean variable values (Zygote): $(mean(samps).nt.mean)")
 

--- a/test/test_3rd_order_estimation.jl
+++ b/test/test_3rd_order_estimation.jl
@@ -70,7 +70,7 @@ mode_estimateNM = Turing.maximum_a_posteriori(Caldara_et_al_2012_loglikelihood,
 
 mode_estimateLBFGS = Turing.maximum_a_posteriori(Caldara_et_al_2012_loglikelihood, 
                                                 Optim.LBFGS(linesearch = LineSearches.BackTracking(order = 3)),
-                                                adtype = ADTypes.AutoZygote(),
+                                                adtype = ADTypes.AutoMooncake(),
                                                 iterations = 100,
                                                 # show_trace = true,
                                                 initial_params = mode_estimateNM.values)
@@ -81,7 +81,7 @@ println("Mode variable values (L-BFGS): $init_params")
 
 n_samples = 100
 
-samps = sample(Caldara_et_al_2012_loglikelihood, NUTS(250, 0.65, adtype = ADTypes.AutoZygote()), n_samples, progress = true, initial_params = init_params)
+samps = sample(Caldara_et_al_2012_loglikelihood, NUTS(250, 0.65, adtype = ADTypes.AutoMooncake()), n_samples, progress = true, initial_params = init_params)
 
 println("Mean variable values (Zygote): $(mean(samps).nt.mean)")
 

--- a/test/test_estimation.jl
+++ b/test/test_estimation.jl
@@ -52,7 +52,7 @@ samps = @time sample(FS2000_loglikelihood, NUTS(), n_samples, progress = true, i
 
 println("Mean variable values (ForwardDiff): $(mean(samps).nt.mean)")
 
-samps = @time sample(FS2000_loglikelihood, NUTS(adtype = ADTypes.AutoZygote()), n_samples, progress = true, initial_params = FS2000.parameter_values)
+samps = @time sample(FS2000_loglikelihood, NUTS(adtype = ADTypes.AutoMooncake()), n_samples, progress = true, initial_params = FS2000.parameter_values)
 
 println("Mean variable values (Zygote): $(mean(samps).nt.mean)")
 
@@ -94,7 +94,7 @@ modeFS2000 = Turing.maximum_a_posteriori(FS2000_loglikelihood,
                                         # Optim.LBFGS(linesearch = LineSearches.BackTracking(order = 2)), 
                                         Optim.LBFGS(linesearch = LineSearches.BackTracking(order = 3)), 
                                         # Optim.NelderMead(), 
-                                        adtype = ADTypes.AutoZygote(), 
+                                        adtype = ADTypes.AutoMooncake(),
                                         # maxiters = 100,
                                         # lb = [0,0,-10,-10,0,0,0,0,0], 
                                         # ub = [1,1,10,10,1,1,1,100,100], 

--- a/test/test_pruned_2nd_order_estimation.jl
+++ b/test/test_pruned_2nd_order_estimation.jl
@@ -47,7 +47,7 @@ Random.seed!(30)
 
 n_samples = 500
 
-samps = @time sample(FS2000_loglikelihood_function(data, FS2000, :pruned_second_order), NUTS(adtype = ADTypes.AutoZygote()), n_samples, progress = true, initial_params = FS2000.parameter_values)
+samps = @time sample(FS2000_loglikelihood_function(data, FS2000, :pruned_second_order), NUTS(adtype = ADTypes.AutoMooncake()), n_samples, progress = true, initial_params = FS2000.parameter_values)
 
 println("Mean variable values (Zygote): $(mean(samps).nt.mean)")
 

--- a/test/test_pruned_3rd_order_estimation.jl
+++ b/test/test_pruned_3rd_order_estimation.jl
@@ -71,7 +71,7 @@ mode_estimateNM = Turing.maximum_a_posteriori(Caldara_et_al_2012_loglikelihood,
 
 mode_estimateLBFGS = Turing.maximum_a_posteriori(Caldara_et_al_2012_loglikelihood, 
                                                 Optim.LBFGS(linesearch = LineSearches.BackTracking(order = 3)),
-                                                adtype = ADTypes.AutoZygote(),
+            adtype = ADTypes.AutoMooncake(),
                                                 iterations = 100,
                                                 # show_trace = true,
                                                 initial_params = mode_estimateNM.values)
@@ -83,7 +83,7 @@ println("Mode variable values (L-BFGS): $init_params")
 
 n_samples = 100
 
-samps = @time sample(Caldara_et_al_2012_loglikelihood, NUTS(250, 0.65, adtype = ADTypes.AutoZygote()), n_samples, progress = true, initial_params = init_params)
+samps = @time sample(Caldara_et_al_2012_loglikelihood, NUTS(250, 0.65, adtype = ADTypes.AutoMooncake()), n_samples, progress = true, initial_params = init_params)
 
 println("Mean variable values (Zygote): $(mean(samps).nt.mean)")
 

--- a/test/test_sw07_estimation.jl
+++ b/test/test_sw07_estimation.jl
@@ -116,7 +116,7 @@ SW07_loglikelihood = SW07_loglikelihood_function(data, Smets_Wouters_2007_linear
 
 n_samples = 1000
 
-samps = @time Turing.sample(SW07_loglikelihood, NUTS(adtype = ADTypes.AutoZygote()), n_samples, 
+samps = @time Turing.sample(SW07_loglikelihood, NUTS(adtype = ADTypes.AutoMooncake()), n_samples,
                             # initial_params = inits,
                             progress = true)
 
@@ -153,7 +153,7 @@ SW07_loglikelihood = SW07_loglikelihood_function(data, Smets_Wouters_2007, obser
 
 n_samples = 1000
 
-samps = @time Turing.sample(SW07_loglikelihood, NUTS(adtype = ADTypes.AutoZygote()), n_samples, 
+samps = @time Turing.sample(SW07_loglikelihood, NUTS(adtype = ADTypes.AutoMooncake()), n_samples,
                             # initial_params = inits,
                             progress = true)
 


### PR DESCRIPTION
## Summary
- add project weakdep and extension for `Mooncake`
- implement `@from_rrule` calls for all ChainRules-based rrules in a new extension
- route Turing examples from Zygote AD to Mooncake

## Testing
- `Pkg.precompile()`

------
https://chatgpt.com/codex/tasks/task_e_68452e83aeec832f99f59d2a8027ece9