### PR TITLE
Move TODO comments to docs

### DIFF
--- a/docs/src/unfinished_docs/todo.md
+++ b/docs/src/unfinished_docs/todo.md
@@ -324,3 +324,23 @@
 - [x] Save plot option
 - [x] Add shock to plot title
 - [x] print model name
+
+## Code notes
+
+The following tasks were extracted from comments in the code base. Each item references the relevant file and context.
+
+- [ ] `src/MacroModelling.jl` (`block_solver`): turn `SS_solve_block` into a proper struct
+- [ ] `src/MacroModelling.jl` (`block_solver`): create functions with Symbolics to reduce compilation time
+- [ ] `src/MacroModelling.jl` (`calculate_third_order_stochastic_steady_state`): verify sparse matrix support
+- [ ] `src/MacroModelling.jl` (`write_functions_mapping!`): investigate slow runtime compared to earlier version
+- [ ] `src/filter/inversion.jl` (`calculate_inversion_filter_loglikelihood`): use subsets of observables and states when propagating states
+- [ ] `src/filter/inversion.jl` (`rrule` for first order): rewrite based on higher order implementation to remove unnecessary matmul
+- [ ] `src/filter/inversion.jl` (`rrule` for first order): add warmup iterations
+- [ ] `src/filter/inversion.jl` (`rrule` for first order): reduce allocations in pullback
+- [ ] `src/filter/inversion.jl` (`rrule` for higher order): clean up length and size handling and avoid temporary vector allocations
+- [ ] `src/filter/find_shocks.jl`: add `ForwardDiff` support for `find_shocks`
+- [ ] `src/filter/kalman.jl`: wrap Lyapunov/Sylvester solvers with a higher level interface
+- [ ] `src/get_functions.jl`: verify derivatives against finite differences
+- [ ] `src/get_functions.jl` (`get_conditional_variance_decomposition`): extend to higher order solutions
+- [ ] `src/get_functions.jl` (`get_variance_decomposition`): extend to higher order solutions
+- [ ] `src/get_functions.jl` (`get_loglikelihood`): error when bounds are violated to catch wrong parameter ordering

--- a/src/MacroModelling.jl
+++ b/src/MacroModelling.jl
@@ -4997,8 +4997,7 @@ function block_solver(parameters_and_solved_vars::Vector{T},
 
     # res = ss_solve_blocks(parameters_and_solved_vars, guess)
 
-    SS_solve_block.ss_problem.func(SS_solve_block.ss_problem.func_buffer, guess, parameters_and_solved_vars) # TODO: make the block a struct
-    # TODO: do the function creation with Symbolics as this will solve the compilation bottleneck for large functions
+    SS_solve_block.ss_problem.func(SS_solve_block.ss_problem.func_buffer, guess, parameters_and_solved_vars)
 
     res = SS_solve_block.ss_problem.func_buffer
 
@@ -5686,7 +5685,6 @@ function calculate_third_order_stochastic_steady_state(::Val{:newton},
                                                         x::Vector{ℱ.Dual{Z,S,N}},
                                                         𝓂::ℳ;
                                                         tol::AbstractFloat = 1e-14)::Tuple{Vector{ℱ.Dual{Z,S,N}}, Bool} where {Z,S,N}
-# TODO: check whether this works with SParseMatrices
     𝐒₁̂ = ℱ.value.(𝐒₁)
     𝐒₂̂ = ℱ.value.(𝐒₂)
     𝐒₃̂ = ℱ.value.(𝐒₃)
@@ -6557,7 +6555,6 @@ function take_nth_order_derivatives(
 end
 
 
-# TODO: check why this takes so much longer than previous implementation
 function write_functions_mapping!(𝓂::ℳ, max_perturbation_order::Int; 
                                     density_threshold::Float64 = .1, 
                                     min_length::Int = 1000,

--- a/src/filter/find_shocks.jl
+++ b/src/filter/find_shocks.jl
@@ -198,7 +198,6 @@ function rrule(::typeof(find_shocks),
 end
 
 
-# TODO: forwarddiff for find_shocks
 @stable default_mode = "disable" begin
 
 function find_shocks(::Val{:LagrangeNewton},

--- a/src/filter/inversion.jl
+++ b/src/filter/inversion.jl
@@ -139,7 +139,6 @@ function calculate_inversion_filter_loglikelihood(::Val{:first_order},
         ℒ.mul!(state, 𝐒, vcat(state[T.past_not_future_and_mixed_idx], x))
         # state = 𝐒 * vcat(state[T.past_not_future_and_mixed_idx], x)
     end
-    # TODO: use subset of observables and states when propagating states (see kalman filter)
 
     # end # timeit_debug
     # end # timeit_debug
@@ -150,7 +149,6 @@ end
 
 end # dispatch_doctor
 
-## TODO: redo this rrule based on the higher order ones. the accumulated matmul might not be necessary at all
 function rrule(::typeof(calculate_inversion_filter_loglikelihood), 
                 ::Val{:first_order}, 
                 state::Vector{Vector{Float64}}, 
@@ -180,7 +178,6 @@ function rrule(::typeof(calculate_inversion_filter_loglikelihood),
     logabsdets = 0.0
 
     @assert warmup_iterations == 0 "Warmup iterations not yet implemented for reverse-mode automatic differentiation."
-    # TODO: implement warmup iterations
 
     state = [copy(state) for _ in 1:size(data_in_deviations,2)+1]
 
@@ -270,7 +267,6 @@ function rrule(::typeof(calculate_inversion_filter_loglikelihood),
     # ∂𝐒obs_idx   = copy(tmp1)
 
     # end # timeit_debug
-    # TODO: optimize allocations
     # pullback
     function inversion_pullback(∂llh)
         # @timeit_debug timer "Inversion filter - pullback" begin    
@@ -859,12 +855,12 @@ function rrule(::typeof(calculate_inversion_filter_loglikelihood),
             end
             
             # aug_state₁ = [state₁; 1; x]
-            # ∂state[1] += ∂aug_state₁[1:length(∂state[1])] # TODO: cleanup length and size references
+            # ∂state[1] += ∂aug_state₁[1:length(∂state[1])]
             ℒ.axpy!(1, ∂aug_state₁[1:length(∂state[1])], ∂state[1])
 
             ∂x = ∂aug_state₁[T.nPast_not_future_and_mixed+2:end]
 
-            # aug_state₂ = [state₂; 0; zero(x)] # TODO: dont allocate new vector here
+            # aug_state₂ = [state₂; 0; zero(x)]
             # ∂state[2] += ∂aug_state₂[1:length(∂state[1])]
             ℒ.axpy!(1, ∂aug_state₂[1:length(∂state[1])], ∂state[2])
 
@@ -2450,7 +2446,7 @@ function rrule(::typeof(calculate_inversion_filter_loglikelihood),
             end
 
             # aug_state₁[i] = [state₁; 1; x[i]]
-            ∂state[1] += ∂aug_state₁[1:length(∂state[1])] # TODO: cleanup length and size references
+            ∂state[1] += ∂aug_state₁[1:length(∂state[1])]
 
             ∂x = ∂aug_state₁[T.nPast_not_future_and_mixed+2:end]
 

--- a/src/filter/kalman.jl
+++ b/src/filter/kalman.jl
@@ -78,7 +78,6 @@ function calculate_kalman_filter_loglikelihood(observables_index::Vector{Int},
     # timer = timer, 
 end
 
-# TODO: use higher level wrapper, like for lyapunov/sylvester
 # Specialization for :theoretical
 function get_initial_covariance(::Val{:theoretical}, 
                                 A::AbstractMatrix{S}, 

--- a/src/get_functions.jl
+++ b/src/get_functions.jl
@@ -1662,7 +1662,6 @@ function get_steady_state(𝓂::ℳ;
     # return 𝓂.SS_solve_func(𝓂)
     # return (var .=> 𝓂.parameter_to_steady_state(𝓂.parameter_values...)[1:length(var)]),  (𝓂.par .=> 𝓂.parameter_to_steady_state(𝓂.parameter_values...)[length(var)+1:end])[getindex(1:length(𝓂.par),map(x->x ∈ collect(𝓂.calibration_equations_parameters),𝓂.par))]
 end
-# TODO: check that derivatives are in line with finitediff
 
 
 """
@@ -2066,7 +2065,6 @@ function get_solution(𝓂::ℳ,
 end
 
 
-# TODO: do this for higher order
 """
 $(SIGNATURES)
 Return the conditional variance decomposition of endogenous variables with regards to the shocks using the linearised solution. 
@@ -2252,7 +2250,6 @@ fevd = get_conditional_variance_decomposition
 
 
 
-# TODO: implement this for higher order
 """
 $(SIGNATURES)
 Return the variance decomposition of endogenous variables with regards to the shocks using the linearised solution. 
@@ -3503,7 +3500,6 @@ function get_loglikelihood(𝓂::ℳ,
     #     sylvester_algorithm = :bicgstab
     # end
 
-    # TODO: throw error for bounds violations, suggesting this might be due to wrong parameter ordering
     @assert length(parameter_values) == length(𝓂.parameters) "The number of parameter values provided does not match the number of parameters in the model. If this function is used in the context of estimation and not all parameters are estimated, you need to combine the estimated parameters with the other model parameters in one `Vector`. Make sure they have the same order they were declared in the `@parameters` block (check by calling `get_parameters`)."
 
     # checks to avoid errors further down the line and inform the user


### PR DESCRIPTION
## Summary
- collect TODO notes from the codebase into docs/src/unfinished_docs/todo.md
- clean up source files by removing inline TODO comments

## Testing
- `julia -t auto snippet.jl`

------
https://chatgpt.com/codex/tasks/task_e_68583087dd64832fae86f5faae4f4c63