### PR TITLE
Refactor OBC ignore handling for IRF utilities

### DIFF
--- a/src/get_functions.jl
+++ b/src/get_functions.jl
@@ -1073,10 +1073,66 @@ get_irf(RBC, RBC.parameter_values)
  0.01        0.002       0.0004      8.0e-5         2.74878e-29  5.49756e-30
 ```
 """
+function process_ignore_obc_flag(shocks,
+                                 ignore_obc::Bool,
+                                 𝓂::ℳ)
+    stochastic_model = length(𝓂.timings.exo) > 0
+    obc_model = length(𝓂.obc_violation_equations) > 0
+
+    obc_shocks_included = false
+
+    if stochastic_model && obc_model
+        if shocks isa Matrix{Float64}
+            obc_indices = contains.(string.(𝓂.timings.exo), "ᵒᵇᶜ")
+            if any(obc_indices)
+                obc_shocks_included = sum(abs2, shocks[obc_indices, :]) > 1e-10
+            end
+        elseif shocks isa KeyedArray{Float64}
+            shock_axis = collect(axiskeys(shocks, 1))
+            shock_axis = shock_axis isa Vector{String} ? shock_axis .|> Meta.parse .|> replace_indices : shock_axis
+
+            obc_shocks = 𝓂.timings.exo[contains.(string.(𝓂.timings.exo), "ᵒᵇᶜ")]
+            relevant_shocks = intersect(obc_shocks, shock_axis)
+
+            if !isempty(relevant_shocks)
+                obc_shocks_included = sum(abs2, shocks(relevant_shocks, :)) > 1e-10
+            end
+        else
+            shock_idx = parse_shocks_input_to_index(shocks, 𝓂.timings)
+
+            selected_shocks = if (shock_idx isa Vector) || (shock_idx isa UnitRange)
+                length(shock_idx) > 0 ? 𝓂.timings.exo[shock_idx] : Symbol[]
+            else
+                [𝓂.timings.exo[shock_idx]]
+            end
+
+            obc_shocks = 𝓂.timings.exo[contains.(string.(𝓂.timings.exo), "ᵒᵇᶜ")]
+            obc_shocks_included = !isempty(intersect(selected_shocks, obc_shocks))
+        end
+    end
+
+    ignore_obc_flag = ignore_obc
+
+    if ignore_obc_flag && !obc_model
+        @info "`ignore_obc = true` has no effect because $(𝓂.model_name) has no occasionally binding constraints."
+        ignore_obc_flag = false
+    end
+
+    if ignore_obc_flag && obc_shocks_included
+        @warn "`ignore_obc = true` cannot be applied because shocks affecting occasionally binding constraints are included. Enforcing the constraints instead."
+        ignore_obc_flag = false
+    end
+
+    occasionally_binding_constraints = obc_model && !ignore_obc_flag
+
+    return ignore_obc_flag, occasionally_binding_constraints, obc_shocks_included
+end
+
+
 function get_irf(𝓂::ℳ,
-                    parameters::Vector{S}; 
-                    periods::Int = 40, 
-                    variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
+                    parameters::Vector{S};
+                    periods::Int = 40,
+                    variables::Union{Symbol_input,String_input} = :all_excluding_obc,
                     shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = :all, 
                     negative_shock::Bool = false, 
                     initial_state::Vector{Float64} = [0.0],
@@ -1286,10 +1342,6 @@ function get_irf(𝓂::ℳ;
 
     @assert !(shocks == :none && generalised_irf) "Cannot compute generalised IRFs for model without shocks."
 
-    stochastic_model = length(𝓂.timings.exo) > 0
-
-    obc_model = length(𝓂.obc_violation_equations) > 0
-
     if shocks isa Matrix{Float64}
         @assert size(shocks)[1] == 𝓂.timings.nExo "Number of rows of provided shock matrix does not correspond to number of shocks. Please provide matrix with as many rows as there are shocks in the model."
 
@@ -1301,7 +1353,6 @@ function get_irf(𝓂::ℳ;
 
         shock_idx = 1
 
-        obc_shocks_included = stochastic_model && obc_model && sum(abs2,shocks[contains.(string.(𝓂.timings.exo),"ᵒᵇᶜ"),:]) > 1e-10
     elseif shocks isa KeyedArray{Float64}
         shock_input = map(x->Symbol(replace(string(x),"₍ₓ₎" => "")),axiskeys(shocks)[1])
 
@@ -1314,19 +1365,11 @@ function get_irf(𝓂::ℳ;
         shock_history[indexin(shock_input, 𝓂.timings.exo),1:size(shocks)[2]] = shocks
 
         shock_idx = 1
-
-        obc_shocks_included = stochastic_model && obc_model && sum(abs2,shocks(intersect(𝓂.timings.exo,axiskeys(shocks,1)),:)) > 1e-10
     else
         shock_idx = parse_shocks_input_to_index(shocks,𝓂.timings)
-
-        obc_shocks_included = stochastic_model && obc_model && (intersect((((shock_idx isa Vector) || (shock_idx isa UnitRange)) && (length(shock_idx) > 0)) ? 𝓂.timings.exo[shock_idx] : [𝓂.timings.exo[shock_idx]], 𝓂.timings.exo[contains.(string.(𝓂.timings.exo),"ᵒᵇᶜ")]) != [])
     end
 
-    if ignore_obc
-        occasionally_binding_constraints = false
-    else
-        occasionally_binding_constraints = length(𝓂.obc_violation_equations) > 0
-    end
+    ignore_obc, occasionally_binding_constraints, obc_shocks_included = process_ignore_obc_flag(shocks, ignore_obc, 𝓂)
 
     # end # timeit_debug
     


### PR DESCRIPTION
## Summary
- add a `process_ignore_obc_flag` helper to centralise occasionally binding constraint handling and user messaging
- reuse the helper from `get_irf`, `plot_irf`, and `plot_irf!` so the ignore flag, enforcement, and OBC shock detection stay consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df92b5ee7c832fa3a352dd27c6e911