### PR TITLE
Centralize default option constants across extensions

### DIFF
--- a/ext/StatsPlotsExt.jl
+++ b/ext/StatsPlotsExt.jl
@@ -3,6 +3,7 @@ module StatsPlotsExt
 using MacroModelling
 
 import MacroModelling: ParameterType, ℳ, Symbol_input, String_input, Tolerances, merge_calculation_options, MODEL®, DATA®, PARAMETERS®, ALGORITHM®, FILTER®, VARIABLES®, SMOOTH®, SHOW_PLOTS®, SAVE_PLOTS®, SAVE_PLOTS_FORMATH®, SAVE_PLOTS_PATH®, PLOTS_PER_PAGE®, MAX_ELEMENTS_PER_LEGENDS_ROW®, EXTRA_LEGEND_SPACE®, PLOT_ATTRIBUTES®, QME®, SYLVESTER®, LYAPUNOV®, TOLERANCES®, VERBOSE®, DATA_IN_LEVELS®, PERIODS®, SHOCKS®, SHOCK_SIZE®, NEGATIVE_SHOCK®, GENERALISED_IRF®, GENERALISED_IRF_WARMUP_ITERATIONS®, GENERALISED_IRF_DRAWS®, INITIAL_STATE®, IGNORE_OBC®, CONDITIONS®, SHOCK_CONDITIONS®, LEVELS®, LABEL®, parse_shocks_input_to_index, parse_variables_input_to_index, replace_indices, filter_data_with_model, get_relevant_steady_states, replace_indices_in_symbol, parse_algorithm_to_state_update, girf, decompose_name, obc_objective_optim_fun, obc_constraint_optim_fun, compute_irf_responses, process_ignore_obc_flag, adjust_generalised_irf_flag, normalize_filtering_options
+import MacroModelling: DEFAULT_ALGORITHM, DEFAULT_FILTER_SELECTOR, DEFAULT_WARMUP_ITERATIONS, DEFAULT_VARIABLES_EXCLUDING_OBC, DEFAULT_SHOCK_SELECTION, DEFAULT_PRESAMPLE_PERIODS, DEFAULT_DATA_IN_LEVELS, DEFAULT_SHOCK_DECOMPOSITION_SELECTOR, DEFAULT_SMOOTH_SELECTOR, DEFAULT_LABEL, DEFAULT_SHOW_PLOTS, DEFAULT_SAVE_PLOTS, DEFAULT_SAVE_PLOTS_FORMAT, DEFAULT_SAVE_PLOTS_PATH, DEFAULT_PLOTS_PER_PAGE_SMALL, DEFAULT_TRANSPARENCY, DEFAULT_MAX_ELEMENTS_PER_LEGEND_ROW, DEFAULT_EXTRA_LEGEND_SPACE, DEFAULT_EMPTY_DICT, DEFAULT_VERBOSE, DEFAULT_TOLERANCES, DEFAULT_QME_ALGORITHM, DEFAULT_SYLVESTER_SELECTOR, DEFAULT_LYAPUNOV_ALGORITHM, DEFAULT_PLOT_ATTRIBUTES, DEFAULT_ARGS_AND_KWARGS_NAMES, DEFAULT_PLOTS_PER_PAGE_LARGE, DEFAULT_SHOCKS_EXCLUDING_OBC, DEFAULT_VARIABLES_EXCLUDING_AUX_AND_OBC, DEFAULT_PERIODS, DEFAULT_SHOCK_SIZE, DEFAULT_NEGATIVE_SHOCK, DEFAULT_GENERALISED_IRF, DEFAULT_GENERALISED_IRF_WARMUP, DEFAULT_GENERALISED_IRF_DRAWS, DEFAULT_INITIAL_STATE, DEFAULT_IGNORE_OBC, DEFAULT_PLOT_TYPE, DEFAULT_CONDITIONS_IN_LEVELS, DEFAULT_SIGMA_RANGE, DEFAULT_FONT_SIZE, DEFAULT_PLOT_TITLE
 import DocStringExtensions: FIELDS, SIGNATURES, TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
 import LaTeXStrings
 
@@ -21,51 +22,6 @@ import MacroModelling: plot_irfs, plot_irf, plot_IRF, plot_simulations, plot_sim
 
 import MacroModelling: plot_irfs!, plot_irf!, plot_IRF!, plot_girf!, plot_simulations!, plot_simulation!, plot_conditional_forecast!, plot_model_estimates!
 
-const default_plot_attributes = Dict(:size=>(700,500),
-                                :plot_titlefont => 10, 
-                                :titlefont => 8, 
-                                :guidefont => 8,
-                                :palette => :auto,
-                                :legendfontsize => 8,
-                                :annotationfontsize => 8,
-                                :legend_title_font_pointsize => 8,
-                                :tickfontsize => 8,
-                                :framestyle => :semi)
-
-# Elements whose difference between function calls should be highlighted across models.
-const args_and_kwargs_names = Dict(:model_name => "Model",
-                                    :algorithm => "Algorithm",
-                                    :shock_names => "Shock",
-                                    :shock_size => "Shock size",
-                                    :negative_shock => "Negative shock",
-                                    :generalised_irf => "Generalised IRF",
-                                    :generalised_irf_warmup_iterations => "Generalised IRF warmup iterations",
-                                    :generalised_irf_draws => "Generalised IRF draws",
-                                    :periods => "Periods",
-                                    :presample_periods => "Presample Periods",
-                                    :ignore_obc => "Ignore OBC",
-                                    :smooth => "Smooth",
-                                    :data => "Data",
-                                    :label => "Label",
-                                    :filter => "Filter",
-                                    :warmup_iterations => "Warmup Iterations",
-                                    :quadratic_matrix_equation_algorithm => "Quadratic Matrix Equation Algorithm",
-                                    :sylvester_algorithm => "Sylvester Algorithm",
-                                    :lyapunov_algorithm => "Lyapunov Algorithm",
-                                    :NSSS_acceptance_tol => "NSSS acceptance tol",
-                                    :NSSS_xtol => "NSSS xtol",
-                                    :NSSS_ftol => "NSSS ftol",
-                                    :NSSS_rel_xtol => "NSSS rel xtol",
-                                    :qme_tol => "QME tol",
-                                    :qme_acceptance_tol => "QME acceptance tol",
-                                    :sylvester_tol => "Sylvester tol",
-                                    :sylvester_acceptance_tol => "Sylvester acceptance tol",
-                                    :lyapunov_tol => "Lyapunov tol",
-                                    :lyapunov_acceptance_tol => "Lyapunov acceptance tol",
-                                    :droptol => "Droptol",
-                                    :dependencies_tol => "Dependencies tol"
-                                    )
-                        
 @stable default_mode = "disable" begin
 """
     gr_backend()
@@ -167,30 +123,30 @@ plot_model_estimates(RBC_CME, simulation([:k],:,:simulate))
 function plot_model_estimates(𝓂::ℳ,
                                 data::KeyedArray{Float64};
                                 parameters::ParameterType = nothing,
-                                algorithm::Symbol = :first_order, 
-                                filter::Symbol = algorithm == :first_order ? :kalman : :inversion, 
-                                warmup_iterations::Int = 0,
-                                variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                                shocks::Union{Symbol_input,String_input} = :all, 
-                                presample_periods::Int = 0,
-                                data_in_levels::Bool = true,
-                                shock_decomposition::Bool = algorithm ∉ (:second_order, :third_order),
-                                smooth::Bool = filter == :kalman,
-                                label::Union{Real, String, Symbol} = 1,
-                                show_plots::Bool = true,
-                                save_plots::Bool = false,
-                                save_plots_format::Symbol = :pdf,
-                                save_plots_path::String = ".",
-                                plots_per_page::Int = 6,
-                                transparency::Float64 = .6,
-                                max_elements_per_legend_row::Int = 4,
-                                extra_legend_space::Float64 = 0.0,
-                                plot_attributes::Dict = Dict(),
-                                verbose::Bool = false,
-                                tol::Tolerances = Tolerances(),
-                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                lyapunov_algorithm::Symbol = :doubling)
+                                algorithm::Symbol = DEFAULT_ALGORITHM, 
+                                filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm), 
+                                warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS,
+                                variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                                shocks::Union{Symbol_input,String_input} = DEFAULT_SHOCK_SELECTION, 
+                                presample_periods::Int = DEFAULT_PRESAMPLE_PERIODS,
+                                data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                                shock_decomposition::Bool = DEFAULT_SHOCK_DECOMPOSITION_SELECTOR(algorithm),
+                                smooth::Bool = DEFAULT_SMOOTH_SELECTOR(filter),
+                                label::Union{Real, String, Symbol} = DEFAULT_LABEL,
+                                show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                                save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                                save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                                save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                                plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_SMALL,
+                                transparency::Float64 = DEFAULT_TRANSPARENCY,
+                                max_elements_per_legend_row::Int = DEFAULT_MAX_ELEMENTS_PER_LEGEND_ROW,
+                                extra_legend_space::Float64 = DEFAULT_EXTRA_LEGEND_SPACE,
+                                plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                                verbose::Bool = DEFAULT_VERBOSE,
+                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                            
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -202,9 +158,9 @@ function plot_model_estimates(𝓂::ℳ,
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -639,28 +595,28 @@ plot_model_estimates!(RBC_CME, simulation([:k],:,:simulate), parameters = :beta 
 function plot_model_estimates!(𝓂::ℳ,
                                 data::KeyedArray{Float64};
                                 parameters::ParameterType = nothing,
-                                algorithm::Symbol = :first_order,
-                                filter::Symbol = algorithm == :first_order ? :kalman : :inversion,
-                                warmup_iterations::Int = 0,
-                                variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                                shocks::Union{Symbol_input,String_input} = :all, 
-                                presample_periods::Int = 0,
-                                data_in_levels::Bool = true,
-                                smooth::Bool = filter == :kalman,
+                                algorithm::Symbol = DEFAULT_ALGORITHM,
+                                filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm),
+                                warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS,
+                                variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                                shocks::Union{Symbol_input,String_input} = DEFAULT_SHOCK_SELECTION, 
+                                presample_periods::Int = DEFAULT_PRESAMPLE_PERIODS,
+                                data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                                smooth::Bool = DEFAULT_SMOOTH_SELECTOR(filter),
                                 label::Union{Real, String, Symbol} = length(model_estimates_active_plot_container) + 1,
-                                show_plots::Bool = true,
-                                save_plots::Bool = false,
-                                save_plots_format::Symbol = :pdf,
-                                save_plots_path::String = ".",
-                                plots_per_page::Int = 6,
-                                max_elements_per_legend_row::Int = 4,
-                                extra_legend_space::Float64 = 0.0,
-                                plot_attributes::Dict = Dict(),
-                                verbose::Bool = false,
-                                tol::Tolerances = Tolerances(),
-                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                lyapunov_algorithm::Symbol = :doubling)
+                                show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                                save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                                save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                                save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                                plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_SMALL,
+                                max_elements_per_legend_row::Int = DEFAULT_MAX_ELEMENTS_PER_LEGEND_ROW,
+                                extra_legend_space::Float64 = DEFAULT_EXTRA_LEGEND_SPACE,
+                                plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                                verbose::Bool = DEFAULT_VERBOSE,
+                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                            
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -672,9 +628,9 @@ function plot_model_estimates!(𝓂::ℳ,
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -811,7 +767,7 @@ function plot_model_estimates!(𝓂::ℳ,
             # get(dict, :filter, nothing) == args_and_kwargs[:filter],
             # get(dict, :warmup_iterations, nothing) == args_and_kwargs[:warmup_iterations],
             # get(dict, :smooth, nothing) == args_and_kwargs[:smooth],
-            all(k == :data ? collect(get(dict, k, nothing)) == collect(get(args_and_kwargs, k, nothing)) : get(dict, k, nothing) == get(args_and_kwargs, k, nothing) for k in setdiff(keys(args_and_kwargs_names),[:label]))
+            all(k == :data ? collect(get(dict, k, nothing)) == collect(get(args_and_kwargs, k, nothing)) : get(dict, k, nothing) == get(args_and_kwargs, k, nothing) for k in setdiff(keys(DEFAULT_ARGS_AND_KWARGS_NAMES),[:label]))
         )))
         for dict in model_estimates_active_plot_container
     ) # "New plot must be different from previous plot. Use the version without ! to plot."
@@ -824,7 +780,7 @@ function plot_model_estimates!(𝓂::ℳ,
 
     # 1. Keep only certain keys from each dictionary
     reduced_vector = [
-        Dict(k => d[k] for k in vcat(:run_id, keys(args_and_kwargs_names)...) if haskey(d, k))
+        Dict(k => d[k] for k in vcat(:run_id, keys(DEFAULT_ARGS_AND_KWARGS_NAMES)...) if haskey(d, k))
         for d in model_estimates_active_plot_container
     ]
 
@@ -835,7 +791,7 @@ function plot_model_estimates!(𝓂::ℳ,
 
     for d in model_estimates_active_plot_container
         model = d[:model_name]
-        d_sub = Dict(k => d[k] for k in setdiff(keys(args_and_kwargs), keys(args_and_kwargs_names)) if haskey(d, k))
+        d_sub = Dict(k => d[k] for k in setdiff(keys(args_and_kwargs), keys(DEFAULT_ARGS_AND_KWARGS_NAMES)) if haskey(d, k))
         push!(get!(grouped_by_model, model, Vector{Dict}()), d_sub)
     end
 
@@ -912,7 +868,7 @@ function plot_model_estimates!(𝓂::ℳ,
                     )
 
         if haskey(diffdict, k)
-            push!(annotate_diff_input, args_and_kwargs_names[k] => reduce(vcat, diffdict[k]))
+            push!(annotate_diff_input, DEFAULT_ARGS_AND_KWARGS_NAMES[k] => reduce(vcat, diffdict[k]))
         end
     end
     
@@ -1370,30 +1326,30 @@ plot_irf(RBC)
 ```
 """
 function plot_irf(𝓂::ℳ;
-                    periods::Int = 40, 
-                    shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = :all_excluding_obc, 
-                    variables::Union{Symbol_input,String_input} = :all_excluding_auxiliary_and_obc,
+                    periods::Int = DEFAULT_PERIODS, 
+                    shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = DEFAULT_SHOCKS_EXCLUDING_OBC, 
+                    variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_AUX_AND_OBC,
                     parameters::ParameterType = nothing,
-                    label::Union{Real, String, Symbol} = 1,
-                    show_plots::Bool = true,
-                    save_plots::Bool = false,
-                    save_plots_format::Symbol = :pdf,
-                    save_plots_path::String = ".",
-                    plots_per_page::Int = 9, 
-                    algorithm::Symbol = :first_order,
-                    shock_size::Real = 1,
-                    negative_shock::Bool = false,
-                    generalised_irf::Bool = false,
-                    generalised_irf_warmup_iterations::Int = 100,
-                    generalised_irf_draws::Int = 50,
-                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = [0.0],
-                    ignore_obc::Bool = false,
-                    plot_attributes::Dict = Dict(),
-                    verbose::Bool = false,
-                    tol::Tolerances = Tolerances(),
-                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                    lyapunov_algorithm::Symbol = :doubling)
+                    label::Union{Real, String, Symbol} = DEFAULT_LABEL,
+                    show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                    save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                    save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                    save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                    plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_LARGE, 
+                    algorithm::Symbol = DEFAULT_ALGORITHM,
+                    shock_size::Real = DEFAULT_SHOCK_SIZE,
+                    negative_shock::Bool = DEFAULT_NEGATIVE_SHOCK,
+                    generalised_irf::Bool = DEFAULT_GENERALISED_IRF,
+                    generalised_irf_warmup_iterations::Int = DEFAULT_GENERALISED_IRF_WARMUP,
+                    generalised_irf_draws::Int = DEFAULT_GENERALISED_IRF_DRAWS,
+                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = DEFAULT_INITIAL_STATE(),
+                    ignore_obc::Bool = DEFAULT_IGNORE_OBC,
+                    plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                    verbose::Bool = DEFAULT_VERBOSE,
+                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -1405,9 +1361,9 @@ function plot_irf(𝓂::ℳ;
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -1737,7 +1693,7 @@ function standard_subplot(::Val{:compare},
                             same_ss::Bool; 
                             xvals = 1:maximum(length.(irf_data)),
                             pal::StatsPlots.ColorPalette = StatsPlots.palette(:auto),
-                            transparency::Float64 = .6) where S <: AbstractFloat
+                            transparency::Float64 = DEFAULT_TRANSPARENCY) where S <: AbstractFloat
     plot_dat = []
     plot_ss = 0
     
@@ -1818,7 +1774,7 @@ function standard_subplot(::Val{:stack},
                             color_total::Symbol = :black,
                             xvals = 1:length(irf_data[1]),
                             pal::StatsPlots.ColorPalette = StatsPlots.palette(:auto),
-                            transparency::Float64 = .6) where S <: AbstractFloat
+                            transparency::Float64 = DEFAULT_TRANSPARENCY) where S <: AbstractFloat
     plot_dat = []
     plot_ss = 0
     
@@ -2032,32 +1988,32 @@ plot_irf!(RBC, shock_size = 2, plot_type = :stack)
 ```
 """
 function plot_irf!(𝓂::ℳ;
-                    periods::Int = 40, 
-                    shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = :all_excluding_obc, 
-                    variables::Union{Symbol_input,String_input} = :all_excluding_auxiliary_and_obc,
+                    periods::Int = DEFAULT_PERIODS, 
+                    shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = DEFAULT_SHOCKS_EXCLUDING_OBC, 
+                    variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_AUX_AND_OBC,
                     parameters::ParameterType = nothing,
                     label::Union{Real, String, Symbol} = length(irf_active_plot_container) + 1,
-                    show_plots::Bool = true,
-                    save_plots::Bool = false,
-                    save_plots_format::Symbol = :pdf,
-                    save_plots_path::String = ".",
-                    plots_per_page::Int = 6, 
-                    algorithm::Symbol = :first_order,
-                    shock_size::Real = 1,
-                    negative_shock::Bool = false,
-                    generalised_irf::Bool = false,
-                    generalised_irf_warmup_iterations::Int = 100,
-                    generalised_irf_draws::Int = 50,
-                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = [0.0],
-                    ignore_obc::Bool = false,
-                    plot_type::Symbol = :compare,
-                    plot_attributes::Dict = Dict(),
-                    transparency::Float64 = .6,
-                    verbose::Bool = false,
-                    tol::Tolerances = Tolerances(),
-                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                    lyapunov_algorithm::Symbol = :doubling)
+                    show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                    save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                    save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                    save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                    plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_SMALL, 
+                    algorithm::Symbol = DEFAULT_ALGORITHM,
+                    shock_size::Real = DEFAULT_SHOCK_SIZE,
+                    negative_shock::Bool = DEFAULT_NEGATIVE_SHOCK,
+                    generalised_irf::Bool = DEFAULT_GENERALISED_IRF,
+                    generalised_irf_warmup_iterations::Int = DEFAULT_GENERALISED_IRF_WARMUP,
+                    generalised_irf_draws::Int = DEFAULT_GENERALISED_IRF_DRAWS,
+                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = DEFAULT_INITIAL_STATE(),
+                    ignore_obc::Bool = DEFAULT_IGNORE_OBC,
+                    plot_type::Symbol = DEFAULT_PLOT_TYPE,
+                    plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                    transparency::Float64 = DEFAULT_TRANSPARENCY,
+                    verbose::Bool = DEFAULT_VERBOSE,
+                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                
 
     @assert plot_type ∈ [:compare, :stack] "plot_type must be either :compare or :stack"
@@ -2071,9 +2027,9 @@ function plot_irf!(𝓂::ℳ;
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -2240,7 +2196,7 @@ function plot_irf!(𝓂::ℳ;
             get(dict, :shock_names, nothing) == args_and_kwargs[:shock_names],
             get(dict, :shocks, nothing) == args_and_kwargs[:shocks],
             get(dict, :initial_state, nothing) == args_and_kwargs[:initial_state],
-            all(get(dict, k, nothing) == get(args_and_kwargs, k, nothing) for k in setdiff(keys(args_and_kwargs_names),[:label]))
+            all(get(dict, k, nothing) == get(args_and_kwargs, k, nothing) for k in setdiff(keys(DEFAULT_ARGS_AND_KWARGS_NAMES),[:label]))
         )))
         for dict in irf_active_plot_container
     )# "New plot must be different from previous plot. Use the version without ! to plot."
@@ -2253,7 +2209,7 @@ function plot_irf!(𝓂::ℳ;
 
     # 1. Keep only certain keys from each dictionary
     reduced_vector = [
-        Dict(k => d[k] for k in vcat(:run_id, :label, keys(args_and_kwargs_names)...) if haskey(d, k))
+        Dict(k => d[k] for k in vcat(:run_id, :label, keys(DEFAULT_ARGS_AND_KWARGS_NAMES)...) if haskey(d, k))
         for d in irf_active_plot_container
     ]
 
@@ -2264,7 +2220,7 @@ function plot_irf!(𝓂::ℳ;
 
     for d in irf_active_plot_container
         model = d[:model_name]
-        d_sub = Dict(k => d[k] for k in setdiff(keys(args_and_kwargs), keys(args_and_kwargs_names)) if haskey(d, k))
+        d_sub = Dict(k => d[k] for k in setdiff(keys(args_and_kwargs), keys(DEFAULT_ARGS_AND_KWARGS_NAMES)) if haskey(d, k))
         push!(get!(grouped_by_model, model, Vector{Dict}()), d_sub)
     end
 
@@ -2283,7 +2239,7 @@ function plot_irf!(𝓂::ℳ;
         end
     end
 
-    # @assert haskey(diffdict, :parameters) || haskey(diffdict, :shock_names) || haskey(diffdict, :initial_state) || any(haskey.(Ref(diffdict), keys(args_and_kwargs_names))) "New plot must be different from previous plot. Use the version without ! to plot."
+    # @assert haskey(diffdict, :parameters) || haskey(diffdict, :shock_names) || haskey(diffdict, :initial_state) || any(haskey.(Ref(diffdict), keys(DEFAULT_ARGS_AND_KWARGS_NAMES))) "New plot must be different from previous plot. Use the version without ! to plot."
     
     annotate_ss = Vector{Pair{String, Any}}[]
 
@@ -2382,7 +2338,7 @@ function plot_irf!(𝓂::ℳ;
                     )
 
         if haskey(diffdict, k)
-            push!(annotate_diff_input, args_and_kwargs_names[k] => reduce(vcat,diffdict[k]))
+            push!(annotate_diff_input, DEFAULT_ARGS_AND_KWARGS_NAMES[k] => reduce(vcat,diffdict[k]))
             
             if k == :negative_shock
                 same_shock_direction = false
@@ -2913,7 +2869,7 @@ function minimal_sigfig_strings(v::AbstractVector{<:Real};
 end
 
 
-function plot_df(plot_vector::Vector{Pair{String,Any}}; fontsize::Real = 8, title::String = "")
+function plot_df(plot_vector::Vector{Pair{String,Any}}; fontsize::Real = DEFAULT_FONT_SIZE, title::String = DEFAULT_PLOT_TITLE)
     # Determine dimensions from plot_vector
     ncols = length(plot_vector)
     nrows = length(plot_vector[1].second)
@@ -3049,21 +3005,21 @@ plot_conditional_variance_decomposition(RBC_CME)
 ```
 """
 function plot_conditional_variance_decomposition(𝓂::ℳ;
-                                                periods::Int = 40, 
+                                                periods::Int = DEFAULT_PERIODS, 
                                                 variables::Union{Symbol_input,String_input} = :all,
                                                 parameters::ParameterType = nothing,
-                                                show_plots::Bool = true,
-                                                save_plots::Bool = false,
-                                                save_plots_format::Symbol = :pdf,
-                                                save_plots_path::String = ".",
-                                                plots_per_page::Int = 9, 
-                                                plot_attributes::Dict = Dict(),
-                                                max_elements_per_legend_row::Int = 4,
-                                                extra_legend_space::Float64 = 0.0,
-                                                verbose::Bool = false,
-                                                tol::Tolerances = Tolerances(),
-                                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                                lyapunov_algorithm::Symbol = :doubling)
+                                                show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                                                save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                                                save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                                                save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                                                plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_LARGE, 
+                                                plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                                                max_elements_per_legend_row::Int = DEFAULT_MAX_ELEMENTS_PER_LEGEND_ROW,
+                                                extra_legend_space::Float64 = DEFAULT_EXTRA_LEGEND_SPACE,
+                                                verbose::Bool = DEFAULT_VERBOSE,
+                                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                                            
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -3073,9 +3029,9 @@ function plot_conditional_variance_decomposition(𝓂::ℳ;
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -3298,20 +3254,20 @@ function plot_solution(𝓂::ℳ,
                         state::Union{Symbol,String};
                         variables::Union{Symbol_input,String_input} = :all,
                         algorithm::Union{Symbol,Vector{Symbol}} = :first_order,
-                        σ::Union{Int64,Float64} = 2,
+                        σ::Union{Int64,Float64} = DEFAULT_SIGMA_RANGE,
                         parameters::ParameterType = nothing,
-                        ignore_obc::Bool = false,
-                        show_plots::Bool = true,
-                        save_plots::Bool = false,
-                        save_plots_format::Symbol = :pdf,
-                        save_plots_path::String = ".",
-                        plots_per_page::Int = 6,
-                        plot_attributes::Dict = Dict(),
-                        verbose::Bool = false,
-                        tol::Tolerances = Tolerances(),
-                        quadratic_matrix_equation_algorithm::Symbol = :schur,
-                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                        lyapunov_algorithm::Symbol = :doubling)
+                        ignore_obc::Bool = DEFAULT_IGNORE_OBC,
+                        show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                        save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                        save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                        save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                        plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_SMALL,
+                        plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                        verbose::Bool = DEFAULT_VERBOSE,
+                        tol::Tolerances = DEFAULT_TOLERANCES(),
+                        quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                        lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                    
     
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -3323,9 +3279,9 @@ function plot_solution(𝓂::ℳ,
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -3671,32 +3627,32 @@ plot_conditional_forecast(RBC_CME, conditions, shocks = shocks, conditions_in_le
 function plot_conditional_forecast(𝓂::ℳ,
                                     conditions::Union{Matrix{Union{Nothing,Float64}}, SparseMatrixCSC{Float64}, KeyedArray{Union{Nothing,Float64}}, KeyedArray{Float64}};
                                     shocks::Union{Matrix{Union{Nothing,Float64}}, SparseMatrixCSC{Float64}, KeyedArray{Union{Nothing,Float64}}, KeyedArray{Float64}, Nothing} = nothing, 
-                                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = [0.0],
-                                    periods::Int = 40, 
+                                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = DEFAULT_INITIAL_STATE(),
+                                    periods::Int = DEFAULT_PERIODS, 
                                     parameters::ParameterType = nothing,
-                                    variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                                    conditions_in_levels::Bool = true,
-                                    algorithm::Symbol = :first_order,
-                                    label::Union{Real, String, Symbol} = 1,
-                                    show_plots::Bool = true,
-                                    save_plots::Bool = false,
-                                    save_plots_format::Symbol = :pdf,
-                                    save_plots_path::String = ".",
-                                    plots_per_page::Int = 9,
-                                    plot_attributes::Dict = Dict(),
-                                    verbose::Bool = false,
-                                    tol::Tolerances = Tolerances(),
-                                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                    lyapunov_algorithm::Symbol = :doubling)
+                                    variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                                    conditions_in_levels::Bool = DEFAULT_CONDITIONS_IN_LEVELS,
+                                    algorithm::Symbol = DEFAULT_ALGORITHM,
+                                    label::Union{Real, String, Symbol} = DEFAULT_LABEL,
+                                    show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                                    save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                                    save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                                    save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                                    plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_LARGE,
+                                    plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                                    verbose::Bool = DEFAULT_VERBOSE,
+                                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time
     
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -4059,26 +4015,26 @@ plot_conditional_forecast!(RBC_CME, conditions, conditions_in_levels = false, pa
 function plot_conditional_forecast!(𝓂::ℳ,
                                     conditions::Union{Matrix{Union{Nothing,Float64}}, SparseMatrixCSC{Float64}, KeyedArray{Union{Nothing,Float64}}, KeyedArray{Float64}};
                                     shocks::Union{Matrix{Union{Nothing,Float64}}, SparseMatrixCSC{Float64}, KeyedArray{Union{Nothing,Float64}}, KeyedArray{Float64}, Nothing} = nothing, 
-                                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = [0.0],
-                                    periods::Int = 40, 
+                                    initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = DEFAULT_INITIAL_STATE(),
+                                    periods::Int = DEFAULT_PERIODS, 
                                     parameters::ParameterType = nothing,
-                                    variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                                    conditions_in_levels::Bool = true,
-                                    algorithm::Symbol = :first_order,
+                                    variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                                    conditions_in_levels::Bool = DEFAULT_CONDITIONS_IN_LEVELS,
+                                    algorithm::Symbol = DEFAULT_ALGORITHM,
                                     label::Union{Real, String, Symbol} = length(conditional_forecast_active_plot_container) + 1,
-                                    show_plots::Bool = true,
-                                    save_plots::Bool = false,
-                                    save_plots_format::Symbol = :pdf,
-                                    save_plots_path::String = ".",
-                                    plots_per_page::Int = 6,
-                                    plot_attributes::Dict = Dict(),
-                                    plot_type::Symbol = :compare,
-                                    transparency::Float64 = .6,
-                                    verbose::Bool = false,
-                                    tol::Tolerances = Tolerances(),
-                                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                    lyapunov_algorithm::Symbol = :doubling)
+                                    show_plots::Bool = DEFAULT_SHOW_PLOTS,
+                                    save_plots::Bool = DEFAULT_SAVE_PLOTS,
+                                    save_plots_format::Symbol = DEFAULT_SAVE_PLOTS_FORMAT,
+                                    save_plots_path::String = DEFAULT_SAVE_PLOTS_PATH,
+                                    plots_per_page::Int = DEFAULT_PLOTS_PER_PAGE_SMALL,
+                                    plot_attributes::Dict = DEFAULT_EMPTY_DICT(),
+                                    plot_type::Symbol = DEFAULT_PLOT_TYPE,
+                                    transparency::Float64 = DEFAULT_TRANSPARENCY,
+                                    verbose::Bool = DEFAULT_VERBOSE,
+                                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time
                  
     @assert plot_type ∈ [:compare, :stack] "plot_type must be either :compare or :stack"
@@ -4086,9 +4042,9 @@ function plot_conditional_forecast!(𝓂::ℳ,
     gr_back = StatsPlots.backend() == StatsPlots.Plots.GRBackend()
 
     if !gr_back
-        attrbts = merge(default_plot_attributes, Dict(:framestyle => :box))
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict(:framestyle => :box))
     else
-        attrbts = merge(default_plot_attributes, Dict())
+        attrbts = merge(DEFAULT_PLOT_ATTRIBUTES, Dict())
     end
 
     attributes = merge(attrbts, plot_attributes)
@@ -4251,7 +4207,7 @@ function plot_conditional_forecast!(𝓂::ℳ,
             get(dict, :conditions, nothing) == args_and_kwargs[:conditions],
             get(dict, :shocks, nothing) == args_and_kwargs[:shocks],
             get(dict, :initial_state, nothing) == args_and_kwargs[:initial_state],
-            all(get(dict, k, nothing) == get(args_and_kwargs, k, nothing) for k in setdiff(keys(args_and_kwargs_names),[:label]))
+            all(get(dict, k, nothing) == get(args_and_kwargs, k, nothing) for k in setdiff(keys(DEFAULT_ARGS_AND_KWARGS_NAMES),[:label]))
         )))
         for dict in conditional_forecast_active_plot_container
     ) # "New plot must be different from previous plot. Use the version without ! to plot."
@@ -4264,7 +4220,7 @@ function plot_conditional_forecast!(𝓂::ℳ,
 
     # 1. Keep only certain keys from each dictionary
     reduced_vector = [
-        Dict(k => d[k] for k in vcat(:run_id, :label, keys(args_and_kwargs_names)...) if haskey(d, k))
+        Dict(k => d[k] for k in vcat(:run_id, :label, keys(DEFAULT_ARGS_AND_KWARGS_NAMES)...) if haskey(d, k))
         for d in conditional_forecast_active_plot_container
     ]
 
@@ -4275,7 +4231,7 @@ function plot_conditional_forecast!(𝓂::ℳ,
 
     for d in conditional_forecast_active_plot_container
         model = d[:model_name]
-        d_sub = Dict(k => d[k] for k in setdiff(keys(args_and_kwargs), keys(args_and_kwargs_names)) if haskey(d, k))
+        d_sub = Dict(k => d[k] for k in setdiff(keys(args_and_kwargs), keys(DEFAULT_ARGS_AND_KWARGS_NAMES)) if haskey(d, k))
         push!(get!(grouped_by_model, model, Vector{Dict}()), d_sub)
     end
 
@@ -4449,7 +4405,7 @@ function plot_conditional_forecast!(𝓂::ℳ,
                     )
 
         if haskey(diffdict, k)
-            push!(annotate_diff_input, args_and_kwargs_names[k] => reduce(vcat,diffdict[k]))
+            push!(annotate_diff_input, DEFAULT_ARGS_AND_KWARGS_NAMES[k] => reduce(vcat,diffdict[k]))
             
             if k == :negative_shock
                 same_shock_direction = false

--- a/ext/TuringExt.jl
+++ b/ext/TuringExt.jl
@@ -7,7 +7,7 @@ import Turing: truncated
 import Turing
 import DocStringExtensions: SIGNATURES
 using DispatchDoctor
-import MacroModelling: Normal, Beta, Cauchy, Gamma, InverseGamma
+import MacroModelling: Normal, Beta, Cauchy, Gamma, InverseGamma, DEFAULT_TURING_USE_MEAN_STD
 
 @stable default_mode = "disable" begin
 
@@ -26,7 +26,7 @@ Constructs a `Beta` distribution, optionally parameterized by its mean and stand
 # Keyword Arguments
 - `μσ` [Type: `Bool`, Default: `false`]: If `true`, `μ` and `σ` are interpreted as the mean and standard deviation to calculate the `α` and `β` parameters.
 """
-function Beta(μ::Real, σ::Real; μσ::Bool=false)
+function Beta(μ::Real, σ::Real; μσ::Bool=DEFAULT_TURING_USE_MEAN_STD)
     if μσ
         # Calculate alpha and beta from mean (μ) and standard deviation (σ)
         ν = μ * (1 - μ) / σ^2 - 1
@@ -51,7 +51,7 @@ Constructs a truncated `Beta` distribution, optionally parameterized by its mean
 # Keyword Arguments
 - `μσ` [Type: `Bool`, Default: `false`]: If `true`, `μ` and `σ` are interpreted as the mean and standard deviation to calculate the `α` and `β` parameters.
 """
-function Beta(μ::Real, σ::Real, lower_bound::Real, upper_bound::Real; μσ::Bool=false)
+function Beta(μ::Real, σ::Real, lower_bound::Real, upper_bound::Real; μσ::Bool=DEFAULT_TURING_USE_MEAN_STD)
     # Create the base distribution, then truncate it
     dist = Beta(μ, σ; μσ=μσ)
     return truncated(dist, lower_bound, upper_bound)
@@ -73,7 +73,7 @@ Constructs an `InverseGamma` distribution, optionally parameterized by its mean 
 # Keyword Arguments
 - `μσ` [Type: `Bool`, Default: `false`]: If `true`, `μ` and `σ` are interpreted as the mean and standard deviation to calculate the shape `α` and scale `β` parameters.
 """
-function InverseGamma(μ::Real, σ::Real; μσ::Bool=false)
+function InverseGamma(μ::Real, σ::Real; μσ::Bool=DEFAULT_TURING_USE_MEAN_STD)
     if μσ
         # Calculate shape (α) and scale (β) from mean (μ) and standard deviation (σ)
         α = (μ / σ)^2 + 2
@@ -97,7 +97,7 @@ Constructs a truncated `InverseGamma` distribution, optionally parameterized by 
 # Keyword Arguments
 - `μσ` [Type: `Bool`, Default: `false`]: If `true`, `μ` and `σ` are interpreted as the mean and standard deviation to calculate the shape `α` and scale `β` parameters.
 """
-function InverseGamma(μ::Real, σ::Real, lower_bound::Real, upper_bound::Real; μσ::Bool=false)
+function InverseGamma(μ::Real, σ::Real, lower_bound::Real, upper_bound::Real; μσ::Bool=DEFAULT_TURING_USE_MEAN_STD)
     # Create the base distribution, then truncate it
     dist = InverseGamma(μ, σ; μσ=μσ)
     return truncated(dist, lower_bound, upper_bound)
@@ -119,7 +119,7 @@ Constructs a `Gamma` distribution, optionally parameterized by its mean and stan
 # Keyword Arguments
 - `μσ` [Type: `Bool`, Default: `false`]: If `true`, `μ` and `σ` are interpreted as the mean and standard deviation to calculate the shape `α` and scale `θ` parameters.
 """
-function Gamma(μ::Real, σ::Real; μσ::Bool=false)
+function Gamma(μ::Real, σ::Real; μσ::Bool=DEFAULT_TURING_USE_MEAN_STD)
     if μσ
         # Calculate shape (α) and scale (θ) from mean (μ) and standard deviation (σ)
         θ = σ^2 / μ
@@ -143,7 +143,7 @@ Constructs a truncated `Gamma` distribution, optionally parameterized by its mea
 # Keyword Arguments
 - `μσ` [Type: `Bool`, Default: `false`]: If `true`, `μ` and `σ` are interpreted as the mean and standard deviation to calculate the shape `α` and scale `θ` parameters.
 """
-function Gamma(μ::Real, σ::Real, lower_bound::Real, upper_bound::Real; μσ::Bool=false)
+function Gamma(μ::Real, σ::Real, lower_bound::Real, upper_bound::Real; μσ::Bool=DEFAULT_TURING_USE_MEAN_STD)
     # Create the base distribution, then truncate it
     dist = Gamma(μ, σ; μσ=μσ)
     return truncated(dist, lower_bound, upper_bound)

--- a/src/Default_Options.jl
+++ b/src/Default_Options.jl
@@ -1,0 +1,127 @@
+# Default option constants shared across MacroModelling components.
+
+# General algorithm and filtering defaults
+const DEFAULT_ALGORITHM = :first_order
+const DEFAULT_FILTER_SELECTOR = algorithm -> algorithm == :first_order ? :kalman : :inversion
+const DEFAULT_SHOCK_DECOMPOSITION_SELECTOR = algorithm -> algorithm ∉ (:second_order, :third_order)
+const DEFAULT_SMOOTH_SELECTOR = filter -> filter == :kalman
+const DEFAULT_WARMUP_ITERATIONS = 0
+const DEFAULT_PRESAMPLE_PERIODS = 0
+const DEFAULT_DATA_IN_LEVELS = true
+const DEFAULT_LEVELS = true
+const DEFAULT_LEVELS_FALSE = false
+const DEFAULT_CONDITIONS_IN_LEVELS = true
+const DEFAULT_IGNORE_OBC = false
+const DEFAULT_SMOOTH_FLAG = true
+
+# Plotting defaults
+const DEFAULT_LABEL = 1
+const DEFAULT_SHOW_PLOTS = true
+const DEFAULT_SAVE_PLOTS = false
+const DEFAULT_SAVE_PLOTS_FORMAT = :pdf
+const DEFAULT_SAVE_PLOTS_PATH = "."
+const DEFAULT_PLOTS_PER_PAGE_SMALL = 6
+const DEFAULT_PLOTS_PER_PAGE_LARGE = 9
+const DEFAULT_TRANSPARENCY = 0.6
+const DEFAULT_MAX_ELEMENTS_PER_LEGEND_ROW = 4
+const DEFAULT_EXTRA_LEGEND_SPACE = 0.0
+const DEFAULT_PLOT_TYPE = :compare
+const DEFAULT_FONT_SIZE = 8
+const DEFAULT_PLOT_TITLE = ""
+
+# Time horizon defaults
+const DEFAULT_PERIODS = 40
+const DEFAULT_CONDITIONAL_VARIANCE_PERIODS = () -> [1:20..., Inf]
+const DEFAULT_AUTOCORRELATION_PERIODS = 1:5
+
+# Shock and variable selections
+const DEFAULT_SHOCK_SELECTION = :all
+const DEFAULT_SHOCKS_EXCLUDING_OBC = :all_excluding_obc
+const DEFAULT_VARIABLE_SELECTION = :all
+const DEFAULT_VARIABLES_EXCLUDING_OBC = :all_excluding_obc
+const DEFAULT_VARIABLES_EXCLUDING_AUX_AND_OBC = :all_excluding_auxiliary_and_obc
+
+# IRF and GIRF defaults
+const DEFAULT_SHOCK_SIZE = 1
+const DEFAULT_NEGATIVE_SHOCK = false
+const DEFAULT_GENERALISED_IRF = false
+const DEFAULT_GENERALISED_IRF_WARMUP = 100
+const DEFAULT_GENERALISED_IRF_DRAWS = 50
+const DEFAULT_INITIAL_STATE = () -> [0.0]
+
+# Moment and statistics defaults
+const DEFAULT_SIGMA_RANGE = 2
+const DEFAULT_NON_STOCHASTIC_STEADY_STATE_FLAG = true
+const DEFAULT_MEAN_FLAG = false
+const DEFAULT_STANDARD_DEVIATION_FLAG = true
+const DEFAULT_VARIANCE_FLAG = false
+const DEFAULT_COVARIANCE_FLAG = false
+const DEFAULT_AUTOCORRELATION_FLAG = false
+const DEFAULT_DERIVATIVES_FLAG = true
+const DEFAULT_STOCHASTIC_FLAG = false
+const DEFAULT_RETURN_VARIABLES_ONLY = false
+const DEFAULT_SILENT_FLAG = false
+
+# Solver and tolerance defaults
+const DEFAULT_VERBOSE = false
+const DEFAULT_QME_ALGORITHM = :schur
+const DEFAULT_LYAPUNOV_ALGORITHM = :doubling
+const DEFAULT_SYLVESTER_ALGORITHM = :doubling
+const DEFAULT_SYLVESTER_SELECTOR = 𝓂 -> sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : DEFAULT_SYLVESTER_ALGORITHM
+const DEFAULT_QME_ALGORITHM_CORRELATION = :doubling
+const DEFAULT_TOLERANCES = Tolerances
+const DEFAULT_EMPTY_DICT = Dict
+
+# StatsPlots specific constants
+const DEFAULT_PLOT_ATTRIBUTES = Dict(
+    :size => (700, 500),
+    :plot_titlefont => 10,
+    :titlefont => 8,
+    :guidefont => 8,
+    :palette => :auto,
+    :legendfontsize => 8,
+    :annotationfontsize => 8,
+    :legend_title_font_pointsize => 8,
+    :tickfontsize => 8,
+    :framestyle => :semi,
+)
+
+const DEFAULT_ARGS_AND_KWARGS_NAMES = Dict(
+    :model_name => "Model",
+    :algorithm => "Algorithm",
+    :shock_names => "Shock",
+    :shock_size => "Shock size",
+    :negative_shock => "Negative shock",
+    :generalised_irf => "Generalised IRF",
+    :generalised_irf_warmup_iterations => "Generalised IRF warmup iterations",
+    :generalised_irf_draws => "Generalised IRF draws",
+    :periods => "Periods",
+    :presample_periods => "Presample Periods",
+    :ignore_obc => "Ignore OBC",
+    :smooth => "Smooth",
+    :data => "Data",
+    :label => "Label",
+    :filter => "Filter",
+    :warmup_iterations => "Warmup Iterations",
+    :quadratic_matrix_equation_algorithm => "Quadratic Matrix Equation Algorithm",
+    :sylvester_algorithm => "Sylvester Algorithm",
+    :lyapunov_algorithm => "Lyapunov Algorithm",
+    :NSSS_acceptance_tol => "NSSS acceptance tol",
+    :NSSS_xtol => "NSSS xtol",
+    :NSSS_ftol => "NSSS ftol",
+    :NSSS_rel_xtol => "NSSS rel xtol",
+    :qme_tol => "QME tol",
+    :qme_acceptance_tol => "QME acceptance tol",
+    :sylvester_tol => "Sylvester tol",
+    :sylvester_acceptance_tol => "Sylvester acceptance tol",
+    :lyapunov_tol => "Lyapunov tol",
+    :lyapunov_acceptance_tol => "Lyapunov acceptance tol",
+    :droptol => "Droptol",
+    :dependencies_tol => "Dependencies tol",
+)
+
+# Turing distribution wrapper defaults
+const DEFAULT_TURING_USE_MEAN_STD = false
+
+# Statistics and steady state selection defaults
+const DEFAULT_STATISTICS_SELECTION_EMPTY = Symbol[]

--- a/src/MacroModelling.jl
+++ b/src/MacroModelling.jl
@@ -108,6 +108,7 @@ using DispatchDoctor
 # Imports
 include("common_docstrings.jl")
 include("options_and_caches.jl")
+include("Default_Options.jl")
 include("structures.jl")
 include("macros.jl")
 include("get_functions.jl")

--- a/src/get_functions.jl
+++ b/src/get_functions.jl
@@ -78,16 +78,16 @@ And data, 4×2×40 Array{Float64, 3}:
 function get_shock_decomposition(𝓂::ℳ,
                                 data::KeyedArray{Float64};
                                 parameters::ParameterType = nothing,
-                                filter::Symbol = algorithm == :first_order ? :kalman : :inversion,
-                                algorithm::Symbol = :first_order,
-                                data_in_levels::Bool = true,
-                                warmup_iterations::Int = 0,
-                                smooth::Bool = filter == :kalman,
-                                verbose::Bool = false,
-                                tol::Tolerances = Tolerances(),
-                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                lyapunov_algorithm::Symbol = :doubling)::KeyedArray
+                                filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm),
+                                algorithm::Symbol = DEFAULT_ALGORITHM,
+                                data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                                warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS,
+                                smooth::Bool = DEFAULT_SMOOTH_SELECTOR(filter),
+                                verbose::Bool = DEFAULT_VERBOSE,
+                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)::KeyedArray
     # @nospecialize # reduce compile time
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -219,16 +219,16 @@ And data, 1×40 Matrix{Float64}:
 function get_estimated_shocks(𝓂::ℳ,
                             data::KeyedArray{Float64};
                             parameters::ParameterType = nothing,
-                            algorithm::Symbol = :first_order, 
-                            filter::Symbol = algorithm == :first_order ? :kalman : :inversion, 
-                            warmup_iterations::Int = 0,
-                            data_in_levels::Bool = true,
-                            smooth::Bool = filter == :kalman,
-                            verbose::Bool = false,
-                            tol::Tolerances = Tolerances(),
-                            quadratic_matrix_equation_algorithm::Symbol = :schur,
-                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                            lyapunov_algorithm::Symbol = :doubling)::KeyedArray
+                            algorithm::Symbol = DEFAULT_ALGORITHM, 
+                            filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm), 
+                            warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS,
+                            data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                            smooth::Bool = DEFAULT_SMOOTH_SELECTOR(filter),
+                            verbose::Bool = DEFAULT_VERBOSE,
+                            tol::Tolerances = DEFAULT_TOLERANCES(),
+                            quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                            lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)::KeyedArray
     # @nospecialize # reduce compile time
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -346,17 +346,17 @@ And data, 4×40 Matrix{Float64}:
 function get_estimated_variables(𝓂::ℳ,
                                 data::KeyedArray{Float64};
                                 parameters::ParameterType = nothing,
-                                algorithm::Symbol = :first_order, 
-                                filter::Symbol = algorithm == :first_order ? :kalman : :inversion, 
-                                warmup_iterations::Int = 0,
-                                data_in_levels::Bool = true,
-                                levels::Bool = true,
-                                smooth::Bool = filter == :kalman,
-                                verbose::Bool = false,
-                                tol::Tolerances = Tolerances(),
-                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                lyapunov_algorithm::Symbol = :doubling)::KeyedArray
+                                algorithm::Symbol = DEFAULT_ALGORITHM, 
+                                filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm), 
+                                warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS,
+                                data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                                levels::Bool = DEFAULT_LEVELS,
+                                smooth::Bool = DEFAULT_SMOOTH_SELECTOR(filter),
+                                verbose::Bool = DEFAULT_VERBOSE,
+                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)::KeyedArray
     # @nospecialize # reduce compile time                         
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -472,18 +472,18 @@ And data, 5×40 Matrix{Float64}:
 function get_model_estimates(𝓂::ℳ,
                              data::KeyedArray{Float64};
                              parameters::ParameterType = nothing,
-                             algorithm::Symbol = :first_order,
-                             filter::Symbol = algorithm == :first_order ? :kalman : :inversion,
-                             warmup_iterations::Int = 0,
-                             data_in_levels::Bool = true,
-                             levels::Bool = true,
-                             smooth::Bool = filter == :kalman,
-                             verbose::Bool = false,
-                             tol::Tolerances = Tolerances(),
-                             quadratic_matrix_equation_algorithm::Symbol = :schur,
+                             algorithm::Symbol = DEFAULT_ALGORITHM,
+                             filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm),
+                             warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS,
+                             data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                             levels::Bool = DEFAULT_LEVELS,
+                             smooth::Bool = DEFAULT_SMOOTH_SELECTOR(filter),
+                             verbose::Bool = DEFAULT_VERBOSE,
+                             tol::Tolerances = DEFAULT_TOLERANCES(),
+                             quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
                              sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} =
                                  sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                             lyapunov_algorithm::Symbol = :doubling)::KeyedArray
+                             lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)::KeyedArray
 
     vars = get_estimated_variables(𝓂, data;
                                    parameters = parameters,
@@ -579,12 +579,12 @@ And data, 4×40 Matrix{Float64}:
 function get_estimated_variable_standard_deviations(𝓂::ℳ,
                                                     data::KeyedArray{Float64};
                                                     parameters::ParameterType = nothing,
-                                                    data_in_levels::Bool = true,
-                                                    smooth::Bool = true,
-                                                    verbose::Bool = false,
-                                                    tol::Tolerances = Tolerances(),
-                                                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                                    lyapunov_algorithm::Symbol = :doubling)
+                                                    data_in_levels::Bool = DEFAULT_DATA_IN_LEVELS,
+                                                    smooth::Bool = DEFAULT_SMOOTH_FLAG,
+                                                    verbose::Bool = DEFAULT_VERBOSE,
+                                                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                                                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                                               
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -733,18 +733,18 @@ And data, 9×42 Matrix{Float64}:
 function get_conditional_forecast(𝓂::ℳ,
                                 conditions::Union{Matrix{Union{Nothing,Float64}}, SparseMatrixCSC{Float64}, KeyedArray{Union{Nothing,Float64}}, KeyedArray{Float64}};
                                 shocks::Union{Matrix{Union{Nothing,Float64}}, SparseMatrixCSC{Float64}, KeyedArray{Union{Nothing,Float64}}, KeyedArray{Float64}, Nothing} = nothing, 
-                                initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = [0.0],
-                                periods::Int = 40, 
+                                initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = DEFAULT_INITIAL_STATE(),
+                                periods::Int = DEFAULT_PERIODS, 
                                 parameters::ParameterType = nothing,
-                                variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                                conditions_in_levels::Bool = true,
-                                algorithm::Symbol = :first_order,
-                                levels::Bool = false,
-                                verbose::Bool = false,
-                                tol::Tolerances = Tolerances(),
-                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                                lyapunov_algorithm::Symbol = :doubling)
+                                variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                                conditions_in_levels::Bool = DEFAULT_CONDITIONS_IN_LEVELS,
+                                algorithm::Symbol = DEFAULT_ALGORITHM,
+                                levels::Bool = DEFAULT_LEVELS_FALSE,
+                                verbose::Bool = DEFAULT_VERBOSE,
+                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                        
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -1060,15 +1060,15 @@ get_irf(RBC, RBC.parameter_values)
 """
 function get_irf(𝓂::ℳ,
                     parameters::Vector{S};
-                    periods::Int = 40,
-                    variables::Union{Symbol_input,String_input} = :all_excluding_obc,
-                    shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = :all, 
-                    negative_shock::Bool = false, 
-                    initial_state::Vector{Float64} = [0.0],
-                    levels::Bool = false,
-                    verbose::Bool = false,
-                    tol::Tolerances = Tolerances(),
-                    quadratic_matrix_equation_algorithm::Symbol = :schur) where S <: Real
+                    periods::Int = DEFAULT_PERIODS,
+                    variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC,
+                    shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = DEFAULT_SHOCK_SELECTION,
+                    negative_shock::Bool = DEFAULT_NEGATIVE_SHOCK, 
+                    initial_state::Vector{Float64} = DEFAULT_INITIAL_STATE(),
+                    levels::Bool = DEFAULT_LEVELS_FALSE,
+                    verbose::Bool = DEFAULT_VERBOSE,
+                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM) where S <: Real
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
         quadratic_matrix_equation_algorithm = quadratic_matrix_equation_algorithm)
@@ -1238,25 +1238,25 @@ And data, 4×40×1 Array{Float64, 3}:
 ```
 """
 function get_irf(𝓂::ℳ; 
-                periods::Int = 40, 
-                algorithm::Symbol = :first_order, 
+                periods::Int = DEFAULT_PERIODS, 
+                algorithm::Symbol = DEFAULT_ALGORITHM, 
                 parameters::ParameterType = nothing,
-                variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = :all_excluding_obc, 
-                negative_shock::Bool = false, 
-                generalised_irf::Bool = false,
-                generalised_irf_warmup_iterations::Int = 100,
-                generalised_irf_draws::Int = 50,
-                initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = [0.0],
-                levels::Bool = false,
-                shock_size::Real = 1,
-                ignore_obc::Bool = false,
+                variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                shocks::Union{Symbol_input,String_input,Matrix{Float64},KeyedArray{Float64}} = DEFAULT_SHOCKS_EXCLUDING_OBC,
+                negative_shock::Bool = DEFAULT_NEGATIVE_SHOCK, 
+                generalised_irf::Bool = DEFAULT_GENERALISED_IRF,
+                generalised_irf_warmup_iterations::Int = DEFAULT_GENERALISED_IRF_WARMUP,
+                generalised_irf_draws::Int = DEFAULT_GENERALISED_IRF_DRAWS,
+                initial_state::Union{Vector{Vector{Float64}},Vector{Float64}} = DEFAULT_INITIAL_STATE(),
+                levels::Bool = DEFAULT_LEVELS_FALSE,
+                shock_size::Real = DEFAULT_SHOCK_SIZE,
+                ignore_obc::Bool = DEFAULT_IGNORE_OBC,
                 # timer::TimerOutput = TimerOutput(),
-                verbose::Bool = false,
-                tol::Tolerances = Tolerances(),
-                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                lyapunov_algorithm::Symbol = :doubling)::KeyedArray
+                verbose::Bool = DEFAULT_VERBOSE,
+                tol::Tolerances = DEFAULT_TOLERANCES(),
+                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)::KeyedArray
     # @nospecialize # reduce compile time            
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -1491,16 +1491,16 @@ And data, 4×6 Matrix{Float64}:
 """
 function get_steady_state(𝓂::ℳ; 
                             parameters::ParameterType = nothing, 
-                            derivatives::Bool = true, 
-                            stochastic::Bool = false,
-                            algorithm::Symbol = :first_order,
-                            parameter_derivatives::Union{Symbol_input,String_input} = :all,
-                            return_variables_only::Bool = false,
-                            verbose::Bool = false,
-                            silent::Bool = false,
-                            tol::Tolerances = Tolerances(),
-                            quadratic_matrix_equation_algorithm::Symbol = :schur,
-                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = :doubling)::KeyedArray
+                            derivatives::Bool = DEFAULT_DERIVATIVES_FLAG, 
+                            stochastic::Bool = DEFAULT_STOCHASTIC_FLAG,
+                            algorithm::Symbol = DEFAULT_ALGORITHM,
+                            parameter_derivatives::Union{Symbol_input,String_input} = DEFAULT_VARIABLE_SELECTION,
+                            return_variables_only::Bool = DEFAULT_RETURN_VARIABLES_ONLY,
+                            verbose::Bool = DEFAULT_VERBOSE,
+                            silent::Bool = DEFAULT_SILENT_FLAG,
+                            tol::Tolerances = DEFAULT_TOLERANCES(),
+                            quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_ALGORITHM)::KeyedArray
     # @nospecialize # reduce compile time
                             
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -1773,12 +1773,12 @@ And data, 4×4 adjoint(::Matrix{Float64}) with eltype Float64:
 """
 function get_solution(𝓂::ℳ; 
                         parameters::ParameterType = nothing,
-                        algorithm::Symbol = :first_order, 
-                        silent::Bool = false,
-                        verbose::Bool = false,
-                        tol::Tolerances = Tolerances(),
-                        quadratic_matrix_equation_algorithm::Symbol = :schur,
-                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = :doubling)::KeyedArray
+                        algorithm::Symbol = DEFAULT_ALGORITHM, 
+                        silent::Bool = DEFAULT_SILENT_FLAG,
+                        verbose::Bool = DEFAULT_VERBOSE,
+                        tol::Tolerances = DEFAULT_TOLERANCES(),
+                        quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_ALGORITHM)::KeyedArray
     # @nospecialize # reduce compile time      
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -1945,11 +1945,11 @@ get_solution(RBC, RBC.parameter_values)
 """
 function get_solution(𝓂::ℳ, 
                         parameters::Vector{S}; 
-                        algorithm::Symbol = :first_order, 
-                        verbose::Bool = false, 
-                        tol::Tolerances = Tolerances(),
-                        quadratic_matrix_equation_algorithm::Symbol = :schur,
-                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = :doubling) where S <: Real
+                        algorithm::Symbol = DEFAULT_ALGORITHM, 
+                        verbose::Bool = DEFAULT_VERBOSE, 
+                        tol::Tolerances = DEFAULT_TOLERANCES(),
+                        quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_ALGORITHM) where S <: Real
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
                                     quadratic_matrix_equation_algorithm = quadratic_matrix_equation_algorithm,
@@ -2147,12 +2147,12 @@ And data, 7×2×21 Array{Float64, 3}:
 ```
 """
 function get_conditional_variance_decomposition(𝓂::ℳ; 
-                                                periods::Union{Vector{Int},Vector{Float64},UnitRange{Int64}} = [1:20...,Inf],
+                                                periods::Union{Vector{Int},Vector{Float64},UnitRange{Int64}} = DEFAULT_CONDITIONAL_VARIANCE_PERIODS(),
                                                 parameters::ParameterType = nothing,  
-                                                verbose::Bool = false,
-                                                tol::Tolerances = Tolerances(),
-                                                quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                                lyapunov_algorithm::Symbol = :doubling)
+                                                verbose::Bool = DEFAULT_VERBOSE,
+                                                tol::Tolerances = DEFAULT_TOLERANCES(),
+                                                quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                                lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time                                            
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -2309,10 +2309,10 @@ And data, 7×2 Matrix{Float64}:
 """
 function get_variance_decomposition(𝓂::ℳ; 
                                     parameters::ParameterType = nothing,
-                                    verbose::Bool = false,
-                                    tol::Tolerances = Tolerances(),
-                                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                                    lyapunov_algorithm::Symbol = :doubling)
+                                    verbose::Bool = DEFAULT_VERBOSE,
+                                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM)
     # @nospecialize # reduce compile time
                                     
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -2437,12 +2437,12 @@ And data, 4×4 Matrix{Float64}:
 """
 function get_correlation(𝓂::ℳ; 
                         parameters::ParameterType = nothing,  
-                        algorithm::Symbol = :first_order,
-                        quadratic_matrix_equation_algorithm::Symbol = :doubling,
-                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                        lyapunov_algorithm::Symbol = :doubling, 
-                        verbose::Bool = false,
-                        tol::Tolerances = Tolerances())
+                        algorithm::Symbol = DEFAULT_ALGORITHM,
+                        quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM_CORRELATION,
+                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                        lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM, 
+                        verbose::Bool = DEFAULT_VERBOSE,
+                        tol::Tolerances = DEFAULT_TOLERANCES())
     # @nospecialize # reduce compile time                    
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -2552,14 +2552,14 @@ And data, 4×5 Matrix{Float64}:
 ```
 """
 function get_autocorrelation(𝓂::ℳ; 
-                            autocorrelation_periods::UnitRange{Int} = 1:5,
+                            autocorrelation_periods::UnitRange{Int} = DEFAULT_AUTOCORRELATION_PERIODS,
                             parameters::ParameterType = nothing,  
-                            algorithm::Symbol = :first_order,
-                            quadratic_matrix_equation_algorithm::Symbol = :schur,
-                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                            lyapunov_algorithm::Symbol = :doubling, 
-                            verbose::Bool = false,
-                            tol::Tolerances = Tolerances())
+                            algorithm::Symbol = DEFAULT_ALGORITHM,
+                            quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                            lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM, 
+                            verbose::Bool = DEFAULT_VERBOSE,
+                            tol::Tolerances = DEFAULT_TOLERANCES())
     # @nospecialize # reduce compile time
     
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -2712,21 +2712,21 @@ And data, 4×6 Matrix{Float64}:
 """
 function get_moments(𝓂::ℳ; 
                     parameters::ParameterType = nothing,  
-                    non_stochastic_steady_state::Bool = true, 
-                    mean::Bool = false,
-                    standard_deviation::Bool = true, 
-                    variance::Bool = false, 
-                    covariance::Bool = false, 
-                    variables::Union{Symbol_input,String_input} = :all_excluding_obc, 
-                    derivatives::Bool = true,
-                    parameter_derivatives::Union{Symbol_input,String_input} = :all,
-                    algorithm::Symbol = :first_order,
-                    silent::Bool = false,
-                    quadratic_matrix_equation_algorithm::Symbol = :schur,
-                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                    lyapunov_algorithm::Symbol = :doubling, 
-                    verbose::Bool = false,
-                    tol::Tolerances = Tolerances())#limit output by selecting pars and vars like for plots and irfs!?
+                    non_stochastic_steady_state::Bool = DEFAULT_NON_STOCHASTIC_STEADY_STATE_FLAG, 
+                    mean::Bool = DEFAULT_MEAN_FLAG,
+                    standard_deviation::Bool = DEFAULT_STANDARD_DEVIATION_FLAG, 
+                    variance::Bool = DEFAULT_VARIANCE_FLAG, 
+                    covariance::Bool = DEFAULT_VARIANCE_FLAG, 
+                    variables::Union{Symbol_input,String_input} = DEFAULT_VARIABLES_EXCLUDING_OBC, 
+                    derivatives::Bool = DEFAULT_DERIVATIVES_FLAG,
+                    parameter_derivatives::Union{Symbol_input,String_input} = DEFAULT_VARIABLE_SELECTION,
+                    algorithm::Symbol = DEFAULT_ALGORITHM,
+                    silent::Bool = DEFAULT_SILENT_FLAG,
+                    quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                    sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                    lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM, 
+                    verbose::Bool = DEFAULT_VERBOSE,
+                    tol::Tolerances = DEFAULT_TOLERANCES())#limit output by selecting pars and vars like for plots and irfs!?
     # @nospecialize # reduce compile time          
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -3238,19 +3238,19 @@ Dict{Symbol, AbstractArray{Float64}} with 1 entry:
 function get_statistics(𝓂,
                         parameter_values::Vector{T};
                         parameters::Union{Vector{Symbol},Vector{String}} = 𝓂.parameters,
-                        non_stochastic_steady_state::Union{Symbol_input,String_input} = Symbol[],
-                        mean::Union{Symbol_input,String_input} = Symbol[],
-                        standard_deviation::Union{Symbol_input,String_input} = Symbol[],
-                        variance::Union{Symbol_input,String_input} = Symbol[],
-                        covariance::Union{Symbol_input,String_input} = Symbol[],
-                        autocorrelation::Union{Symbol_input,String_input} = Symbol[],
-                        autocorrelation_periods::UnitRange{Int} = 1:5,
-                        algorithm::Symbol = :first_order,
-                        quadratic_matrix_equation_algorithm::Symbol = :schur,
-                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                        lyapunov_algorithm::Symbol = :doubling,
-                        verbose::Bool = false,
-                        tol::Tolerances = Tolerances()) where T
+                        non_stochastic_steady_state::Union{Symbol_input,String_input} = DEFAULT_STATISTICS_SELECTION_EMPTY,
+                        mean::Union{Symbol_input,String_input} = DEFAULT_STATISTICS_SELECTION_EMPTY,
+                        standard_deviation::Union{Symbol_input,String_input} = DEFAULT_STATISTICS_SELECTION_EMPTY,
+                        variance::Union{Symbol_input,String_input} = DEFAULT_STATISTICS_SELECTION_EMPTY,
+                        covariance::Union{Symbol_input,String_input} = DEFAULT_STATISTICS_SELECTION_EMPTY,
+                        autocorrelation::Union{Symbol_input,String_input} = DEFAULT_STATISTICS_SELECTION_EMPTY,
+                        autocorrelation_periods::UnitRange{Int} = DEFAULT_AUTOCORRELATION_PERIODS,
+                        algorithm::Symbol = DEFAULT_ALGORITHM,
+                        quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM,
+                        sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                        lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM,
+                        verbose::Bool = DEFAULT_VERBOSE,
+                        tol::Tolerances = DEFAULT_TOLERANCES()) where T
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
                         quadratic_matrix_equation_algorithm = quadratic_matrix_equation_algorithm,
@@ -3260,9 +3260,9 @@ function get_statistics(𝓂,
 
     @assert length(parameter_values) == length(parameters) "Vector of `parameters` must correspond to `parameter_values` in length and order. Define the parameter names in the `parameters` keyword argument."
     
-    @assert algorithm ∈ [:first_order, :pruned_second_order, :pruned_third_order] || !(!(standard_deviation == Symbol[]) || !(mean == Symbol[]) || !(variance == Symbol[]) || !(covariance == Symbol[]) || !(autocorrelation == Symbol[])) "Statistics can only be provided for first order perturbation or second and third order pruned perturbation solutions."
+    @assert algorithm ∈ [:first_order, :pruned_second_order, :pruned_third_order] || !(!(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(mean == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(covariance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY)) "Statistics can only be provided for first order perturbation or second and third order pruned perturbation solutions."
 
-    @assert !(non_stochastic_steady_state == Symbol[]) || !(standard_deviation == Symbol[]) || !(mean == Symbol[]) || !(variance == Symbol[]) || !(covariance == Symbol[]) || !(autocorrelation == Symbol[]) "Provide variables for at least one output."
+    @assert !(non_stochastic_steady_state == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(mean == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(covariance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY) "Provide variables for at least one output."
 
     SS_var_idx = @ignore_derivatives parse_variables_input_to_index(non_stochastic_steady_state, 𝓂.timings)
 
@@ -3285,11 +3285,11 @@ function get_statistics(𝓂,
 
     solved = true
 
-    if algorithm == :pruned_third_order && !(!(standard_deviation == Symbol[]) || !(variance == Symbol[]) || !(covariance == Symbol[]) || !(autocorrelation == Symbol[]))
+    if algorithm == :pruned_third_order && !(!(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(covariance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY))
         algorithm = :pruned_second_order
     end
 
-    if !(non_stochastic_steady_state == Symbol[]) && (standard_deviation == Symbol[]) && (variance == Symbol[]) && (covariance == Symbol[]) && (autocorrelation == Symbol[])
+    if !(non_stochastic_steady_state == DEFAULT_STATISTICS_SELECTION_EMPTY) && (standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY) && (variance == DEFAULT_STATISTICS_SELECTION_EMPTY) && (covariance == DEFAULT_STATISTICS_SELECTION_EMPTY) && (autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY)
         SS_and_pars, (solution_error, iters) = get_NSSS_and_parameters(𝓂, all_parameters, opts = opts) # timer = timer, 
         
         SS = SS_and_pars[1:end - length(𝓂.calibration_equations)]
@@ -3305,12 +3305,12 @@ function get_statistics(𝓂,
 
     if algorithm == :pruned_third_order
 
-        if !(autocorrelation == Symbol[])
+        if !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY)
             second_mom_third_order = union(autocorr_var_idx, std_var_idx, var_var_idx, covar_var_idx)
 
             covar_dcmp, state_μ, autocorr, SS_and_pars, solved = calculate_third_order_moments_with_autocorrelation(all_parameters, 𝓂.var[second_mom_third_order], 𝓂, opts = opts, autocorrelation_periods = autocorrelation_periods)
 
-        elseif !(standard_deviation == Symbol[]) || !(variance == Symbol[]) || !(covariance == Symbol[])
+        elseif !(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(covariance == DEFAULT_STATISTICS_SELECTION_EMPTY)
 
             covar_dcmp, state_μ, SS_and_pars, solved = calculate_third_order_moments(all_parameters, 𝓂.var[union(std_var_idx, var_var_idx, covar_var_idx)], 𝓂, opts = opts)
 
@@ -3318,7 +3318,7 @@ function get_statistics(𝓂,
 
     elseif algorithm == :pruned_second_order
 
-        if !(standard_deviation == Symbol[]) || !(variance == Symbol[]) || !(covariance == Symbol[]) || !(autocorrelation == Symbol[])
+        if !(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(covariance == DEFAULT_STATISTICS_SELECTION_EMPTY) || !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY)
             covar_dcmp, Σᶻ₂, state_μ, Δμˢ₂, autocorr_tmp, ŝ_to_ŝ₂, ŝ_to_y₂, Σʸ₁, Σᶻ₁, SS_and_pars, 𝐒₁, ∇₁, 𝐒₂, ∇₂, solved = calculate_second_order_moments_with_covariance(all_parameters, 𝓂, opts = opts)
         else
             state_μ, Δμˢ₂, Σʸ₁, Σᶻ₁, SS_and_pars, 𝐒₁, ∇₁, 𝐒₂, ∇₂, solved = calculate_second_order_moments(all_parameters, 𝓂, opts = opts)
@@ -3332,14 +3332,14 @@ function get_statistics(𝓂,
 
     SS = SS_and_pars[1:end - length(𝓂.calibration_equations)]
 
-    if !(variance == Symbol[])
+    if !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY)
         varrs = convert(Vector{T},max.(ℒ.diag(covar_dcmp),eps(Float64)))
-        if !(standard_deviation == Symbol[])
+        if !(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY)
             st_dev = sqrt.(varrs)
         end
     end
 
-    if !(autocorrelation == Symbol[])
+    if !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY)
         if algorithm == :pruned_second_order
             ŝ_to_ŝ₂ⁱ = zero(ŝ_to_ŝ₂)
             ŝ_to_ŝ₂ⁱ += ℒ.diagm(ones(size(ŝ_to_ŝ₂,1)))
@@ -3361,7 +3361,7 @@ function get_statistics(𝓂,
         end
     end
 
-    if !(standard_deviation == Symbol[])
+    if !(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY)
         st_dev = sqrt.(abs.(convert(Vector{T}, max.(ℒ.diag(covar_dcmp),eps(Float64)))))
     end
         
@@ -3369,11 +3369,11 @@ function get_statistics(𝓂,
     # ret = AbstractArray{T}[]
     ret = Dict{Symbol,AbstractArray{T}}()
 
-    if !(non_stochastic_steady_state == Symbol[])
+    if !(non_stochastic_steady_state == DEFAULT_STATISTICS_SELECTION_EMPTY)
         # push!(ret,SS[SS_var_idx])
         ret[:non_stochastic_steady_state] = solved ? SS[SS_var_idx] : fill(Inf * sum(abs2,parameter_values), isnothing(SS_var_idx) ? 0 : length(SS_var_idx))
     end
-    if !(mean == Symbol[])
+    if !(mean == DEFAULT_STATISTICS_SELECTION_EMPTY)
         if algorithm ∉ [:pruned_second_order,:pruned_third_order]
             # push!(ret,SS[mean_var_idx])
             ret[:mean] = solved ? SS[mean_var_idx] : fill(Inf * sum(abs2,parameter_values), isnothing(mean_var_idx) ? 0 : length(mean_var_idx))
@@ -3382,15 +3382,15 @@ function get_statistics(𝓂,
             ret[:mean] = solved ? state_μ[mean_var_idx] : fill(Inf * sum(abs2,parameter_values), isnothing(mean_var_idx) ? 0 : length(mean_var_idx))
         end
     end
-    if !(standard_deviation == Symbol[])
+    if !(standard_deviation == DEFAULT_STATISTICS_SELECTION_EMPTY)
         # push!(ret,st_dev[std_var_idx])
         ret[:standard_deviation] = solved ? st_dev[std_var_idx] : fill(Inf * sum(abs2,parameter_values), isnothing(std_var_idx) ? 0 : length(std_var_idx))
     end
-    if !(variance == Symbol[])
+    if !(variance == DEFAULT_STATISTICS_SELECTION_EMPTY)
         # push!(ret,varrs[var_var_idx])
         ret[:variance] = solved ? varrs[var_var_idx] : fill(Inf * sum(abs2,parameter_values), isnothing(var_var_idx) ? 0 : length(var_var_idx))
     end
-    if !(covariance == Symbol[])
+    if !(covariance == DEFAULT_STATISTICS_SELECTION_EMPTY)
         covar_dcmp_sp = (ℒ.triu(covar_dcmp))
 
         # droptol!(covar_dcmp_sp,eps(Float64))
@@ -3398,7 +3398,7 @@ function get_statistics(𝓂,
         # push!(ret,covar_dcmp_sp[covar_var_idx,covar_var_idx])
         ret[:covariance] = solved ? covar_dcmp_sp[covar_var_idx,covar_var_idx] : fill(Inf * sum(abs2,parameter_values),isnothing(covar_var_idx) ? 0 : length(covar_var_idx), isnothing(covar_var_idx) ? 0 : length(covar_var_idx))
     end
-    if !(autocorrelation == Symbol[]) 
+    if !(autocorrelation == DEFAULT_STATISTICS_SELECTION_EMPTY) 
         # push!(ret,autocorr[autocorr_var_idx,:] )
         ret[:autocorrelation] = solved ? autocorr[autocorr_var_idx,:] : fill(Inf * sum(abs2,parameter_values), isnothing(autocorr_var_idx) ? 0 : length(autocorr_var_idx), isnothing(autocorrelation_periods) ? 0 : length(autocorrelation_periods))
     end
@@ -3465,18 +3465,18 @@ get_loglikelihood(RBC, simulated_data([:k], :, :simulate), RBC.parameter_values)
 function get_loglikelihood(𝓂::ℳ, 
                             data::KeyedArray{Float64}, 
                             parameter_values::Vector{S}; 
-                            algorithm::Symbol = :first_order, 
-                            filter::Symbol = algorithm == :first_order ? :kalman : :inversion, 
+                            algorithm::Symbol = DEFAULT_ALGORITHM, 
+                            filter::Symbol = DEFAULT_FILTER_SELECTOR(algorithm), 
                             on_failure_loglikelihood::U = -Inf,
-                            warmup_iterations::Int = 0, 
+                            warmup_iterations::Int = DEFAULT_WARMUP_ITERATIONS, 
                             presample_periods::Int = 0,
                             initial_covariance::Symbol = :theoretical,
                             filter_algorithm::Symbol = :LagrangeNewton,
-                            tol::Tolerances = Tolerances(), 
-                            quadratic_matrix_equation_algorithm::Symbol = :schur, 
-                            lyapunov_algorithm::Symbol = :doubling, 
-                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = sum(1:𝓂.timings.nPast_not_future_and_mixed + 1 + 𝓂.timings.nExo) > 1000 ? :bicgstab : :doubling,
-                            verbose::Bool = false)::S where {S <: Real, U <: AbstractFloat}
+                            tol::Tolerances = DEFAULT_TOLERANCES(), 
+                            quadratic_matrix_equation_algorithm::Symbol = DEFAULT_QME_ALGORITHM, 
+                            lyapunov_algorithm::Symbol = DEFAULT_LYAPUNOV_ALGORITHM, 
+                            sylvester_algorithm::Union{Symbol,Vector{Symbol},Tuple{Symbol,Vararg{Symbol}}} = DEFAULT_SYLVESTER_SELECTOR(𝓂),
+                            verbose::Bool = DEFAULT_VERBOSE)::S where {S <: Real, U <: AbstractFloat}
                             # timer::TimerOutput = TimerOutput(),
 
     opts = merge_calculation_options(tol = tol, verbose = verbose,
@@ -3609,8 +3609,8 @@ And data, 5-element Vector{Float64}:
 function get_non_stochastic_steady_state_residuals(𝓂::ℳ, 
                                                     values::Union{Vector{Float64}, Dict{Symbol, Float64}, Dict{String, Float64}, KeyedArray{Float64, 1}}; 
                                                     parameters::ParameterType = nothing,
-                                                    tol::Tolerances = Tolerances(),
-                                                    verbose::Bool = false)
+                                                    tol::Tolerances = DEFAULT_TOLERANCES(),
+                                                    verbose::Bool = DEFAULT_VERBOSE)
     # @nospecialize # reduce compile time                                             
 
     opts = merge_calculation_options(tol = tol, verbose = verbose)


### PR DESCRIPTION
## Summary
- add a `Default_Options` module that exposes shared constant definitions for default values
- update StatsPlots and Turing extensions to import the centralized defaults
- refactor get_functions defaults to reuse the shared constants for filtering, plotting, and statistics options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e018619200832fa9ac2e3328effe8f